### PR TITLE
实现图文混合聊天

### DIFF
--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -1,47 +1,102 @@
-const axios = require('axios')
-const uuid = require('uuid')
-const accountManager = require('./account.js')
-const { sleep } = require('./tools.js')
+// lib/request.js
+const axios = require('axios');
+const uuid = require('uuid');
+const accountManager = require('./account.js');
+const { sleep } = require('./tools.js');
 
 const sendChatRequest = async (body) => {
-
-  if (accountManager) {
-    const models = await accountManager.getModels()
-    if (!models.includes(body.model)) {
-      body.model = 'qwen3-235b-a22b'
+  // 确保 accountManager 存在且 getModels 是一个函数
+  if (accountManager && typeof accountManager.getModels === 'function') {
+    try {
+      const models = await accountManager.getModels();
+      if (models && !models.includes(body.model)) {
+        console.warn(`[警告] 模型 ${body.model} 不在已知模型列表中，将使用默认模型 qwen-turbo。`);
+        body.model = 'qwen-turbo';
+      }
+    } catch (modelsError) {
+      console.error("[错误] 获取模型列表失败:", modelsError);
+      body.model = body.model || 'qwen-turbo'; // Fallback if model list fetch fails
     }
+  } else {
+    console.warn("[警告] accountManager 或 getModels 方法未定义，无法验证模型。将使用请求中指定的模型或默认模型。");
+    body.model = body.model || 'qwen-turbo'; // Fallback if accountManager is not set up
   }
 
   try {
-    // console.log(JSON.stringify(body))
+    // console.log("发送到 Qwen API 的请求体:", JSON.stringify(body, null, 2)); // Sensitive data, remove for production
     const response = await axios.post('https://chat.qwen.ai/api/chat/completions',
       body,
       {
         headers: accountManager.getHeaders(),
-        responseType: body.stream ? 'stream' : 'json'
+        responseType: body.stream ? 'stream' : 'json',
+        timeout: body.stream ? 120000 : 60000 // Longer timeout for streams
       }
-    )
+    );
 
     return {
-      status: 200,
+      status: response.status,
       response: response.data
-    }
-  }
-  catch (error) {
-    console.log("发送请求失败:", error.status || error.response.status || error.code)
-    if (error.status === 429 || error.response.status === 429 || error.code === 429) {
-      await sleep(1000)
-      return sendChatRequest(body)
-    }
-    // process.exit(0)
-    return {
-      status: 500,
-      response: null
-    }
-  }
+    };
+  } catch (error) {
+    let statusCode = 500;
+    let errorMessage = "与通义千问服务通信时发生未知错误。";
+    let errorCode = null; // For specific error codes like EAI_AGAIN
+    let qwenErrorData = null;
 
-}
+    if (axios.isAxiosError(error)) {
+      console.error("Axios 请求通义千问API失败:");
+      if (error.response) {
+        // The request was made and the server responded with a status code
+        // that falls out of the range of 2xx
+        statusCode = error.response.status;
+        qwenErrorData = error.response.data;
+        errorMessage = (qwenErrorData && qwenErrorData.message) ? qwenErrorData.message : `通义千问服务返回错误: ${statusCode}`;
+        console.error(`  状态码: ${statusCode}`);
+        console.error(`  响应数据:`, JSON.stringify(qwenErrorData, null, 2));
+      } else if (error.request) {
+        // The request was made but no response was received
+        errorMessage = "通义千问服务未响应或网络连接错误。";
+        console.error(`  无响应: ${errorMessage}`);
+        if (error.code) { // E.g., ECONNABORTED, ENOTFOUND, EAI_AGAIN
+            errorCode = error.code;
+            errorMessage += ` (错误码: ${errorCode})`;
+            console.error(`  错误码: ${errorCode}`);
+            // Set more specific HTTP status codes for the client based on network error codes
+            if (errorCode === 'ECONNABORTED') statusCode = 504; // Gateway Timeout
+            else if (errorCode === 'ENOTFOUND' || errorCode === 'EAI_AGAIN') statusCode = 503; // Service Unavailable (DNS issue)
+            else statusCode = 503; // Service Unavailable (Other network issues)
+        }
+      } else {
+        // Something happened in setting up the request that triggered an Error
+        errorMessage = `设置通义千问请求时出错: ${error.message}`;
+        console.error(`  请求设置错误: ${error.message}`);
+      }
+    } else {
+      // Non-Axios error
+      console.error("发送请求到通义千问前发生非Axios错误:", error);
+      errorMessage = error.message || "处理请求时发生内部错误。";
+    }
+
+    // Retry logic for specific status codes (e.g., 429 Too Many Requests)
+    if (statusCode === 429) {
+      console.log(`[信息] 收到 429 Too Many Requests，将在1秒后重试...`);
+      await sleep(1000); // Ensure sleep is defined and works as expected
+      return sendChatRequest(body); // Recursive call for retry
+    }
+
+    return {
+      status: statusCode,
+      error: {
+        message: errorMessage,
+        code: errorCode,
+        qwen_response: qwenErrorData,
+        // request_body: body // Including request_body can expose sensitive data, use with caution
+      },
+      response: null
+    };
+  }
+};
 
 module.exports = {
   sendChatRequest
-}
+};

--- a/src/router/chat.js
+++ b/src/router/chat.js
@@ -1,324 +1,503 @@
-const express = require('express')
-const router = express.Router()
-const uuid = require('uuid')
-const { uploadImage } = require('../lib/upload.js')
-const { isJson } = require('../lib/tools.js')
-const { sendChatRequest } = require('../lib/request.js')
-const accountManager = require('../lib/account.js')
-const config = require('../config.js')
-const { apiKeyVerify } = require('../router/index.js')
+// router/chat.js
+/**
+ * 处理聊天完成请求 (/v1/chat/completions)
+ * 支持两种请求类型:
+ * 1. application/json: 遵循 OpenAI 格式，图片以 Base64 Data URI 形式在 messages 中提供。
+ * 服务器会自动处理 Base64 上传并替换 URL。
+ * 2. multipart/form-data: 包含文本字段 ('messages' JSON 字符串) 和可选的图片文件 ('file')。
+ * 服务器会处理上传的文件。
+ *
+ * 最终都会将包含图片 URL (如果提供) 和文本的消息发送给通义千问 API。
+ */
+const express = require('express');
+const router = express.Router();
+const uuid = require('uuid');
+const multer = require('multer'); // 用于处理 multipart/form-data
+const { isJson } = require('../lib/tools.js');
+const { sendChatRequest } = require('../lib/request.js');
+const accountManager = require('../lib/account.js');
+const config = require('../config.js');
+const { apiKeyVerify } = require('../router/index.js');
+const { uploadFileToQwenOss } = require('../lib/qwen_file_uploader');
+const { Buffer } = require('buffer');
+const { TextDecoder } = require('util');
+const mimetypes = require('mime-types'); // 用于从 Data URI 获取类型
 
+// 配置 Multer 使用内存存储，仅用于 multipart 请求
+const storage = multer.memoryStorage();
+const upload = multer({
+  storage: storage,
+  limits: { fileSize: 10 * 1024 * 1024 } // 限制文件大小, 例如 10MB
+});
 
-const isChatType = (model, search) => {
-  if (model.includes('-search') || search) {
-    return 'search'
-  } else {
-    return 't2t'
-  }
-}
-
+/**
+ * 检查模型是否启用了思考模式。
+ * @param {string} model - 模型名称。
+ * @param {boolean|string} enable_thinking - 是否强制启用思考。
+ * @param {number|string} thinking_budget - 思考预算。
+ * @returns {object} 思考配置对象。
+ */
 const isThinkingEnabled = (model, enable_thinking, thinking_budget) => {
-
   const thinking_config = {
     "output_schema": "phase",
     "thinking_enabled": false,
-    "thinking_budget": 38912
+    "thinking_budget": 38912 // 默认预算值
+  };
+  // 检查模型名称或参数是否明确启用思考
+  if ((model && model.includes('-thinking')) || enable_thinking === true || String(enable_thinking).toLowerCase() === 'true') {
+    thinking_config.thinking_enabled = true;
   }
-
-  if (model.includes('-thinking') || enable_thinking) {
-    thinking_config.thinking_enabled = true
+  // 检查并设置有效的思考预算
+  if (thinking_budget && !isNaN(Number(thinking_budget)) && Number(thinking_budget) > 0 && Number(thinking_budget) < 38912) {
+    thinking_config.budget = Number(thinking_budget);
   }
+  return thinking_config;
+};
 
-  if (thinking_budget && Number(thinking_budget) !== Number.NaN && Number(thinking_budget) > 0 && Number(thinking_budget) < 38912) {
-    thinking_config.budget = Number(thinking_budget)
-  }
-
-  return thinking_config
-}
-
+/**
+ * 解析并清理模型名称，移除特定后缀。
+ * @param {string} model - 原始模型名称。
+ * @returns {string} 清理后的模型名称。
+ */
 const parserModel = (model) => {
-  if (!model) return 'qwen3-235b-a22b'
-
+  if (!model) return 'qwen-turbo'; // 提供一个合理的默认模型
   try {
-    model = String(model)
-    model = model.replace('-search', '')
-    model = model.replace('-thinking', '')
-    return model
+    let parsed = String(model);
+    // 移除行为控制后缀，保留能力标识后缀
+    parsed = parsed.replace(/-search/g, '');
+    parsed = parsed.replace(/-thinking/g, '');
+    return parsed;
   } catch (e) {
-    return 'qwen3-235b-a22b'
+    console.error("解析模型名称失败:", e);
+    return 'qwen-turbo'; // 出错时回退
   }
-}
+};
 
-const parserMessages = (messages, thinking_config, chat_type) => {
+/**
+ * 处理流式响应，将 Qwen API 的 SSE 流转发给客户端。
+ * @param {object} res - Express 响应对象。
+ * @param {ReadableStream} responseStream - 从通义千问 API 获取的响应流。
+ * @param {boolean} enable_thinking - 是否启用了思考输出。
+ * @param {boolean} enable_web_search - 是否启用了网页搜索。
+ */
+const streamResponse = async (res, responseStream, enable_thinking, enable_web_search) => {
   try {
+    const message_id = uuid.v4();
+    const decoder = new TextDecoder('utf-8');
+    let web_search_info = null;
+    let thinking_start = false;
+    let thinking_end = false;
 
-    const feature_config = thinking_config
-    messages.forEach(message => {
-      if (message.role === 'user' || message.role === 'assistant') {
-        message.chat_type = "t2t"
-        message.extra = {}
-        message.feature_config = {
-          "output_schema": "phase",
-          "thinking_enabled": false,
-        }
+    responseStream.on('data', async (chunk) => {
+      // 确保响应流仍然可写
+      if (!res.writable || res.writableEnded) {
+        console.warn("[警告] 尝试写入已结束的响应流。");
+        if (responseStream && typeof responseStream.destroy === 'function') responseStream.destroy(); // 停止读取源流
+        return;
       }
-    })
+      const decodeText = decoder.decode(chunk, { stream: true });
+      const lists = decodeText.split('\n').filter(item => item.trim() !== ''); // 分割可能的多条消息
 
-    messages[messages.length - 1].feature_config = feature_config
-    messages[messages.length - 1].chat_type = chat_type
-
-    return messages
-  } catch (e) {
-    return [
-      {
-        "role": "user",
-        "content": "直接返回字符串： '聊天历史处理有误...'",
-        "chat_type": "t2t",
-        "extra": {},
-        "feature_config": {
-          "output_schema": "phase",
-          "enabled": false,
-        }
-      }
-    ]
-  }
-}
-
-const markBody = (req, res, next) => {
-  try {
-
-    // 构建请求体
-    const body = {
-      "stream": true,
-      "incremental_output": true,
-      "chat_type": "t2t",
-      "model": "qwen3-235b-a22b",
-      "messages": [],
-      "session_id": uuid.v4(),
-      "chat_id": uuid.v4(),
-      "id": uuid.v4(),
-      "sub_chat_type": "t2t",
-      "chat_mode": "normal"
-    }
-
-    // 获取请求体原始数据
-    let {
-      messages,            // 消息历史
-      model,               // 模型
-      stream,              // 流式输出
-      search,              // 搜索模式
-      enable_thinking,     // 是否启用思考
-      thinking_budget      // 思考预算
-    } = req.body
-
-    // 处理 stream 参数
-    if (stream === true || stream === 'true') {
-      body.stream = true
-    } else {
-      body.stream = false
-    }
-    // 处理 incremental_output 参数 : 是否增量输出
-    body.incremental_output = true
-    // 处理 chat_type 参数 : 聊天类型
-    body.chat_type = isChatType(model, search)
-    req.enable_web_search = body.chat_type === 'search' ? true : false
-    // 处理 model 参数 : 模型
-    body.model = parserModel(model)
-    // 处理 messages 参数 : 消息历史
-    body.messages = parserMessages(messages, isThinkingEnabled(model, enable_thinking, thinking_budget), body.chat_type)
-    req.enable_thinking = isThinkingEnabled(model, enable_thinking, thinking_budget).enabled
-    // 处理 sub_chat_type 参数 : 子聊天类型
-    body.sub_chat_type = body.chat_type
-
-
-    req.body = body
-    next()
-  } catch (e) {
-    console.log(e)
-    res.status(500)
-      .json({
-        status: 500,
-        message: "在处理请求体时发生错误 ~ ~ ~"
-      })
-  }
-}
-
-const streamResponse = async (res, response, enable_thinking, enable_web_search) => {
-  try {
-    const message_id = uuid.v4()
-    const decoder = new TextDecoder('utf-8')
-    let web_search_info = null
-    let thinking_start = false
-    let thinking_end = false
-
-    response.on('data', async (chunk) => {
-      const decodeText = decoder.decode(chunk, { stream: true })
-      // console.log(decodeText)
-      const lists = decodeText.split('\n').filter(item => item.trim() !== '')
       for (const item of lists) {
-        try {
-          let decodeJson = isJson(item.replace("data: ", '')) ? JSON.parse(item.replace("data: ", '')) : null
-          if (decodeJson === null || !decodeJson.choices || decodeJson.choices.length === 0) {
-            continue
-          }
+        if (!res.writable || res.writableEnded) break; // 再次检查流状态
 
-          // 处理 web_search 信息
-          if (decodeJson.choices[0].delta.name === 'web_search') {
-            web_search_info = decodeJson.choices[0].delta.extra.web_search_info
-            // console.log(web_search_info)
-          }
-
-          if (!decodeJson.choices[0].delta.content || (decodeJson.choices[0].delta.phase !== 'think' && decodeJson.choices[0].delta.phase !== 'answer')) return
-
-          let content = decodeJson.choices[0].delta.content
-
-          if (decodeJson.choices[0].delta.phase === 'think' && !thinking_start) {
-            thinking_start = true
-            if (web_search_info) {
-              content = `<think>\n\n${await accountManager.generateMarkdownTable(web_search_info, config.searchInfoMode)}\n\n${content}`
-            } else {
-              content = `<think>\n\n${content}`
+        if (item.trim() === 'data: [DONE]') {
+          // 如果禁用了思考输出，且有搜索结果，在这里附加搜索结果
+          if ((config.outThink === false || !enable_thinking) && web_search_info && !thinking_start) {
+            try {
+              const webSearchTable = await accountManager.generateMarkdownTable(web_search_info, config.searchInfoMode || "text");
+              const searchStreamTemplate = { id: `chatcmpl-${message_id}-search`, object: "chat.completion.chunk", created: Date.now(), choices: [{ index: 0, delta: { content: `\n\n---\n${webSearchTable}` }, finish_reason: null }] };
+              res.write(`data: ${JSON.stringify(searchStreamTemplate)}\n\n`);
+            } catch (tableError) {
+              console.error("生成搜索结果 Markdown 表失败:", tableError);
             }
           }
-          if (decodeJson.choices[0].delta.phase === 'answer' && !thinking_end && thinking_start) {
-            thinking_end = true
-            content = `\n\n</think>\n${content}`
+          res.write(`data: [DONE]\n\n`); // 发送最终的 [DONE] 标记
+          if (!res.writableEnded) res.end();
+          return; // 处理完 DONE 后退出循环
+        }
+
+        try {
+          const jsonData = item.replace(/^data: /, '');
+          if (!jsonData) continue; // 避免空字符串导致 JSON.parse 错误
+          const decodeJson = isJson(jsonData) ? JSON.parse(jsonData) : null;
+          if (!decodeJson) continue; // 如果不是有效 JSON，跳过
+
+          // 提取 web_search 信息
+          if (decodeJson.choices && decodeJson.choices[0]?.delta?.name === 'web_search' && decodeJson.choices[0]?.delta?.extra) {
+            web_search_info = decodeJson.choices[0].delta.extra.web_search_info;
+          }
+
+          let content = decodeJson.choices?.[0]?.delta?.content ?? '';
+          const phase = decodeJson.choices?.[0]?.delta?.phase;
+
+          // 处理思考标签 (如果启用)
+          if (enable_thinking && config.outThink) {
+            if (phase === 'think' && !thinking_start) {
+              thinking_start = true;
+              let prefix = "<think>\n\n";
+              if (web_search_info) {
+                try {
+                  prefix += `${await accountManager.generateMarkdownTable(web_search_info, config.searchInfoMode)}\n\n`;
+                } catch (tableError) {
+                  console.error("生成搜索结果 Markdown 表失败 (思考模式):", tableError);
+                }
+              }
+              content = prefix + content;
+            }
+            if (phase === 'answer' && thinking_start && !thinking_end) {
+              thinking_end = true;
+              content = `\n\n</think>\n` + content;
+            }
           }
 
           const StreamTemplate = {
-            "id": `chatcmpl-${message_id}`,
-            "object": "chat.completion.chunk",
-            "created": new Date().getTime(),
-            "choices": [
-              {
-                "index": 0,
-                "delta": {
-                  "content": content
-                },
-                "finish_reason": null
-              }
-            ]
+            id: decodeJson.id || `chatcmpl-${message_id}`,
+            object: decodeJson.object || "chat.completion.chunk",
+            created: decodeJson.created || Date.now(),
+            model: decodeJson.model || "",
+            choices: [{
+              index: 0,
+              delta: { content: content },
+              finish_reason: (decodeJson.choices && decodeJson.choices[0] ? decodeJson.choices[0].finish_reason : null) ?? null
+            }],
+            usage: decodeJson.usage || null
+          };
+          if (decodeJson.choices?.[0]?.delta?.role) { // 如果 delta 中包含 role，也添加到响应中
+            StreamTemplate.choices[0].delta.role = decodeJson.choices[0].delta.role;
           }
 
-          res.write(`data: ${JSON.stringify(StreamTemplate)}\n\n`)
+          res.write(`data: ${JSON.stringify(StreamTemplate)}\n\n`);
         } catch (error) {
-          console.log(error)
-          res.status(500).json({ error: "服务错误!!!" })
+          console.error('解析或处理流数据块时出错:', item, error);
         }
       }
-    })
+    });
 
-    response.on('end', async () => {
-      if ((config.outThink === false || !enable_thinking) && web_search_info) {
-        const webSearchTable = await accountManager.generateMarkdownTable(web_search_info, config.searchInfoMode || "text")
-        res.write(`data: ${JSON.stringify({
-          "id": `chatcmpl-${id}`,
-          "object": "chat.completion.chunk",
-          "created": new Date().getTime(),
-          "choices": [
-            {
-              "index": 0,
-              "delta": {
-                "content": `\n\n---\n${web_search_info}`
+    responseStream.on('error', (err) => {
+      console.error('源响应流发生错误:', err);
+      if (res.writable && !res.writableEnded) {
+        try {
+          const errorChunk = { id: `chatcmpl-${message_id}-error`, object: "chat.completion.chunk", created: Date.now(), choices: [{ index: 0, delta: { content: `\n\n[服务流错误: ${err.message}]` }, finish_reason: "error" }] };
+          res.write(`data: ${JSON.stringify(errorChunk)}\n\n`);
+          res.write(`data: [DONE]\n\n`);
+        } catch (writeError) {
+            console.error("写入流错误信息失败:", writeError);
+        } finally {
+            if (!res.writableEnded) res.end();
+        }
+      } else if (!res.headersSent) {
+         try { // 如果头部未发送，可以尝试发送 JSON 错误
+             res.status(500).json({ error: `服务流错误: ${err.message}` });
+         } catch (jsonError) {
+             console.error("发送 JSON 错误响应失败:", jsonError);
+         }
+      }
+    });
+
+    responseStream.on('end', async () => {
+      console.log('源响应流已结束。');
+      if (res.writable && !res.writableEnded) {
+          // 检查是否需要在结束时附加搜索结果
+          if ((config.outThink === false || !enable_thinking) && web_search_info && !thinking_start) {
+              try {
+                const webSearchTable = await accountManager.generateMarkdownTable(web_search_info, config.searchInfoMode || "text");
+                const searchStreamTemplate = { id: `chatcmpl-${message_id}-search-end`, object: "chat.completion.chunk", created: Date.now(), choices: [{ index: 0, delta: { content: `\n\n---\n${webSearchTable}` }, finish_reason: null }] };
+                res.write(`data: ${JSON.stringify(searchStreamTemplate)}\n\n`);
+              } catch (tableError) {
+                  console.error("结束时生成搜索结果 Markdown 表失败:", tableError);
+              }
+          }
+          res.write(`data: [DONE]\n\n`); // 确保最终的 DONE 标记
+          res.end();
+      }
+    });
+
+  } catch (error) {
+    console.error('处理流式响应时发生顶层错误:', error);
+    if (res.writable && !res.writableEnded) {
+        try {
+            res.write(`data: ${JSON.stringify({ choices: [{ delta: { content: `\n[处理流响应错误: ${error.message}]`}}]})}\n\n`);
+            res.write(`data: [DONE]\n\n`);
+        } catch (writeError) {
+            console.error("写入顶层错误到流失败:", writeError);
+        } finally {
+            if (!res.writableEnded) res.end();
+        }
+    } else if (!res.headersSent) {
+        try {
+            res.status(500).json({ error: `处理流式响应时发生严重错误: ${error.message}` });
+        } catch (jsonError) {
+            console.error("发送顶层 JSON 错误响应失败:", jsonError);
+        }
+    }
+  }
+};
+
+/**
+ * 处理非流式响应，将 Qwen API 的 JSON 响应格式化后返回给客户端。
+ * @param {object} res - Express 响应对象。
+ * @param {object} qwenResponse - 从通义千问 API 获取的完整 JSON 响应。
+ * @param {boolean} enable_thinking - 是否启用了思考输出。
+ * @param {boolean} enable_web_search - 是否启用了网页搜索。
+ * @param {string} model - 使用的模型名称。
+ */
+const notStreamResponse = async (res, qwenResponse, enable_thinking, enable_web_search, model) => {
+  try {
+    // 增加对 qwenResponse 结构的健壮性检查
+    if (!qwenResponse?.choices?.[0]?.message) {
+        console.error("无效的 Qwen 非流式响应结构:", qwenResponse);
+        if (!res.headersSent) { // 避免在已发送响应头后再次发送
+            return res.status(500).json({ error: "收到来自 Qwen API 的无效响应。" });
+        }
+        return; // 如果已发送，则无法再响应
+    }
+
+    let finalContent = qwenResponse.choices[0].message.content || "";
+    let web_search_info = qwenResponse.choices[0].message.extra?.web_search_info;
+
+    // 如果不输出思考过程，但有搜索结果，则附加搜索结果
+    if ((config.outThink === false || !enable_thinking) && web_search_info) {
+        try {
+            const webSearchTable = await accountManager.generateMarkdownTable(web_search_info, config.searchInfoMode || "text");
+            finalContent += `\n\n---\n${webSearchTable}`;
+        } catch (tableError) {
+            console.error("非流式响应中生成搜索结果 Markdown 表失败:", tableError);
+            // 可以选择附加原始 web_search_info 或错误提示
+            finalContent += `\n\n---\n[无法格式化搜索结果]`;
+        }
+    }
+
+    // 构建 OpenAI 兼容的响应体
+    const responseBody = {
+      id: qwenResponse.id || `chatcmpl-${uuid.v4()}`,
+      object: qwenResponse.object || "chat.completion",
+      created: qwenResponse.created || Math.floor(Date.now() / 1000),
+      model: model,
+      choices: [{
+        index: 0,
+        message: {
+          role: "assistant",
+          content: finalContent
+        },
+        finish_reason: qwenResponse.choices[0].finish_reason || "stop"
+      }],
+      usage: qwenResponse.usage || { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
+    };
+    if (!res.headersSent) { // 确保在发送前头部未被发送
+        res.json(responseBody);
+    } else {
+        console.error("无法发送非流式响应，因为头部已发送。");
+    }
+  } catch (error) {
+    console.error('处理非流式响应时发生错误:', error, "原始Qwen响应:", qwenResponse);
+    if (!res.headersSent) {
+        res.status(500).json({ error: "处理响应时发生内部错误。" });
+    }
+  }
+};
+
+
+/**
+ * POST /v1/chat/completions
+ * 核心路由处理器：根据 Content-Type 处理 application/json 或 multipart/form-data 请求。
+ */
+router.post(
+  `${config.apiPrefix ? config.apiPrefix : ''}/v1/chat/completions`,
+  apiKeyVerify, // 验证 API Key
+  // upload.fields 仅在 Content-Type 是 multipart/form-data 时生效
+  upload.fields([ { name: 'file', maxCount: 1 } ]),
+  async (req, res) => {
+    let setResHeaderStatus = false;
+    // 函数：安全地设置响应头 (流式或 JSON)
+    const setResHeader = (isStream) => {
+        if (setResHeaderStatus || res.headersSent) return; // 防止重复设置或在发送后设置
+        try {
+          res.set(isStream
+            ? { 'Content-Type': 'text/event-stream; charset=utf-8', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive' }
+            : { 'Content-Type': 'application/json; charset=utf-8' });
+          setResHeaderStatus = true;
+        } catch (e) { console.error("设置响应头失败:", e); }
+    };
+
+    try {
+      // 1. 提取请求数据 (区分 JSON 和 Multipart)
+      let model, messagesData, streamStr, search, enable_thinking, thinking_budget, session_id, chat_id;
+      let uploadedFile = null;
+      let isMultipart = false;
+
+      if (req.is('multipart/form-data')) {
+          console.log("[信息] 收到 multipart/form-data 请求。");
+          isMultipart = true;
+          ({ model, messages: messagesData, stream: streamStr, search, enable_thinking, thinking_budget, session_id, chat_id } = req.body);
+          uploadedFile = req.files?.file?.[0];
+      } else if (req.is('application/json')) {
+          console.log("[信息] 收到 application/json 请求。");
+          ({ model, messages: messagesData, stream: streamStr, search, enable_thinking, thinking_budget, session_id, chat_id } = req.body);
+      } else {
+          return res.status(415).json({ error: '不支持的 Content-Type。请使用 application/json 或 multipart/form-data。' });
+      }
+
+      // 2. 解析 messages (处理字符串或对象数组)
+      let messages;
+      try {
+        if (isMultipart) {
+            if (typeof messagesData !== 'string' || messagesData.trim() === '') { throw new Error("multipart 请求中缺少 'messages' 字段或其值为空字符串。"); }
+            messages = JSON.parse(messagesData);
+        } else {
+            if (!Array.isArray(messagesData)) { throw new Error("application/json 请求中 'messages' 字段必须是数组。"); }
+            messages = messagesData;
+        }
+        if (!Array.isArray(messages) || messages.length === 0 || !messages[0]?.role || messages[0]?.content === undefined) {
+             throw new Error("解析后的 messages 格式无效或内容缺失。");
+        }
+      } catch (e) {
+        console.error("解析 messages 失败:", e.message, "收到的字段内容:", messagesData);
+        if (!res.headersSent) { return res.status(400).json({ error: `解析 messages 失败: ${e.message}` }); }
+        else { console.error("无法发送400错误，头部已发送。"); if (res.writable && !res.writableEnded) res.end(); return; }
+      }
+
+      // 3. 处理其他参数
+      const stream = String(streamStr).toLowerCase() === 'true';
+      const parsedModel = parserModel(model);
+      const hasImage = uploadedFile || messages.some(msg =>
+          msg.role === 'user' && Array.isArray(msg.content) &&
+          msg.content.some(item =>
+              (item.type === 'image_url' && item.image_url?.url?.startsWith('data:image')) ||
+              (item.type === 'image' && typeof item.image === 'string' && item.image.startsWith('data:image'))
+          )
+      );
+      const baseChatType = hasImage ? 'vision' : ((parsedModel && parsedModel.includes('-search')) || search ? 'search' : 't2t');
+      const thinkingConfig = isThinkingEnabled(parsedModel, enable_thinking, thinking_budget);
+      const enable_thinking_flag = thinkingConfig.thinking_enabled;
+      const enable_web_search_flag = baseChatType === 'search';
+
+      let imageUrl = null;
+      let qwenAuthToken = null;
+
+      // 4. 处理图片上传 (区分文件和 Base64)
+      if (uploadedFile) { // 处理 multipart 上传的文件
+        console.log(`[信息] 处理上传的文件: ${uploadedFile.originalname}`);
+        qwenAuthToken = accountManager.getAccountToken();
+        if (!qwenAuthToken) { throw new Error('无法获取内部认证Token进行文件上传。'); }
+        try {
+          const uploadResult = await uploadFileToQwenOss(uploadedFile.buffer, uploadedFile.originalname, qwenAuthToken);
+          imageUrl = uploadResult.file_url;
+          console.log(`[+] 文件上传成功，URL: ${imageUrl}`);
+        } catch (uploadError) { throw new Error(`处理文件上传失败: ${uploadError.message || '未知上传错误'}`); }
+
+      } else { // 检查 application/json 请求中的 Base64
+        for (let i = 0; i < messages.length; i++) {
+          const msg = messages[i];
+          if (msg.role === 'user' && Array.isArray(msg.content)) {
+            for (let j = 0; j < msg.content.length; j++) {
+              const item = msg.content[j];
+              let base64Uri = null;
+              if (item.type === 'image_url' && item.image_url?.url?.startsWith('data:image')) {
+                  base64Uri = item.image_url.url;
+              } else if (item.type === 'image' && typeof item.image === 'string' && item.image.startsWith('data:image')) {
+                  // 支持直接在 image 字段放 Base64 URI (非标准，为增加兼容性)
+                  base64Uri = item.image;
+              }
+
+              if (base64Uri) {
+                console.log("[信息] 检测到 Base64 图片数据，开始处理上传...");
+                if (!qwenAuthToken) qwenAuthToken = accountManager.getAccountToken();
+                if (!qwenAuthToken) { throw new Error('无法获取内部认证Token进行 Base64 上传。'); }
+                try {
+                  const matches = base64Uri.match(/^data:(image\/.*?);base64,(.*)$/);
+                  if (!matches || matches.length !== 3) { throw new Error('无效的 Base64 Data URI 格式。'); }
+                  const mimeType = matches[1];
+                  const base64Data = matches[2];
+                  const fileBuffer = Buffer.from(base64Data, 'base64');
+                  const fileExtension = mimetypes.extension(mimeType) || 'png';
+                  const originalFilename = `image_from_base64_${Date.now()}.${fileExtension}`;
+
+                  const uploadResult = await uploadFileToQwenOss(fileBuffer, originalFilename, qwenAuthToken);
+                  imageUrl = uploadResult.file_url;
+                  console.log(`[+] Base64 图片上传成功，URL: ${imageUrl}`);
+                  // 将 Base64 替换为 URL，并统一格式为 Qwen 的 image 类型
+                  messages[i].content[j] = { type: "image", image: imageUrl };
+                  break; // 只处理找到的第一个 Base64 图片 (根据需求)
+                } catch (uploadError) { throw new Error(`处理 Base64 图片上传失败: ${uploadError.message || '未知上传错误'}`); }
               }
             }
-          ]
-        })}\n\n`)
-      }
-      res.write(`data: [DONE]\n\n`)
-      res.end()
-    })
-  } catch (error) {
-    console.log(error)
-    res.status(500).json({ error: "服务错误!!!" })
-  }
-}
-
-const notStreamResponse = async (res, response, enable_thinking, enable_web_search, model) => {
-  try {
-    const bodyTemplate = {
-      "id": `chatcmpl-${uuid.v4()}`,
-      "object": "chat.completion",
-      "created": new Date().getTime(),
-      "model": model,
-      "choices": [
-        {
-          "index": 0,
-          "message": {
-            "role": "assistant",
-            "content": response.choices[0].message.content
-          },
-          "finish_reason": "stop"
+          }
+          if (imageUrl) break; // 如果已找到并处理 Base64，跳出外层循环 (因为只支持一张图片)
         }
-      ],
-      "usage": {
-        "prompt_tokens": 512,
-        "completion_tokens": response.choices[0].message.content.length,
-        "total_tokens": 512 + response.choices[0].message.content.length
       }
-    }
-    res.json(bodyTemplate)
-  } catch (error) {
-    console.log(error)
-    res.status(500)
-      .json({
-        error: "服务错误!!!"
-      })
-  }
-}
 
-router.post(`${config.apiPrefix ? config.apiPrefix : ''}/v1/chat/completions`, apiKeyVerify, markBody, async (req, res) => {
-  const { stream, enable_thinking, enable_web_search, model } = req.body
-  let setResHeaderStatus = false
+      // 5. 构建最终的 messages 数组 (确保 content 是数组，转换 image_url)
+      messages = messages.map(msg => {
+           if (typeof msg.content === 'string') {
+               msg.content = [{ type: "text", text: msg.content }];
+           } else if (!Array.isArray(msg.content) && msg.content != null) {
+               console.warn("[警告] 消息 content 格式非预期，尝试包装:", msg.content);
+               msg.content = [{ type: "text", text: String(msg.content) }];
+           } else if (Array.isArray(msg.content)) {
+               // 转换 OpenAI 的 image_url (如果不是 Base64 且未被替换) 为 Qwen 的 image 格式
+               msg.content = msg.content.map(item => {
+                   if (item.type === 'image_url' && item.image_url?.url && !item.image_url.url.startsWith('data:image')) {
+                       return { type: "image", image: item.image_url.url };
+                   }
+                   if (item.type === 'text' && item.text === undefined) {
+                       item.text = ''; // 确保 text 类型有 text 字段
+                   }
+                   if (item.type === 'image' && item.image === undefined) {
+                       // 如果 image 字段缺失，可能需要移除此项或报错
+                       console.warn("[警告] 发现 type 为 image 但缺少 image 字段的项目:", item);
+                       return null; // 标记为 null，稍后过滤
+                   }
+                   return item;
+               }).filter(item => item !== null); // 过滤掉无效项
+           }
+           return msg;
+       });
+      // 如果有上传的文件但 messages 结构不适合插入，创建新消息
+      if (imageUrl && !(messages.length > 0 && messages[0].role === 'user' && Array.isArray(messages[0].content))) {
+          console.warn("[警告] 收到图片但无法添加到现有 messages 结构中，创建新的用户消息。");
+          messages.push({ role: "user", content: [ {type: "image", image: imageUrl} ] });
+      }
 
-  const setResHeader = (stream) => {
-    if (setResHeaderStatus) return
-    try {
+
+      // 6. 构建发送给 Qwen API 的请求体
+      const bodyToQwen = { stream: stream, incremental_output: true, model: parsedModel, messages: messages, session_id: session_id || uuid.v4(), chat_id: chat_id || uuid.v4(), id: uuid.v4(), chat_type: baseChatType, sub_chat_type: baseChatType, chat_mode: "normal" };
+      if (messages.length > 0) { const lastMsgIndex = messages.length - 1; messages[lastMsgIndex].feature_config = { ...(messages[lastMsgIndex].feature_config || {}), ...thinkingConfig }; messages[lastMsgIndex].chat_type = baseChatType; }
+      if (baseChatType === 'vision' && !parsedModel.toLowerCase().includes('vl')) { console.warn(`[!] 警告: 消息中包含图片，但选择的模型 '${parsedModel}' 可能不是视觉模型。`); }
+
+      // 7. 发送请求到 Qwen API
+      const qwenApiResponse = await sendChatRequest(bodyToQwen);
+
+      // 8. 处理 Qwen API 的响应
+      if (qwenApiResponse.status !== 200 || qwenApiResponse.error) {
+        console.error("请求通义千问API失败或返回错误:", qwenApiResponse.error || `状态码: ${qwenApiResponse.status}`);
+        const errorDetail = qwenApiResponse.error ? (qwenApiResponse.error.message || JSON.stringify(qwenApiResponse.error)) : `请求通义千问API失败，状态码: ${qwenApiResponse.status}`;
+        setResHeader(stream);
+        if (stream && res.writable && !res.writableEnded) { const errorChunk = { id: `chatcmpl-${uuid.v4()}-apierror`, object: "chat.completion.chunk", created: Date.now(), choices: [{ index: 0, delta: { content: `\n\n[API请求错误: ${errorDetail}]` }, finish_reason: "error" }] }; res.write(`data: ${JSON.stringify(errorChunk)}\n\n`); res.write(`data: [DONE]\n\n`); if (!res.writableEnded) res.end(); }
+        else { if (!res.headersSent) { res.status(qwenApiResponse.status || 500).json({ error: errorDetail }); } else { console.error("无法发送JSON错误响应，头部已发送。"); if (!res.writableEnded) res.end(); } }
+        return;
+      }
+
+      // 9. 发送成功响应
+      setResHeader(stream);
       if (stream) {
-        res.set({
-          'Content-Type': 'text/event-stream',
-          'Cache-Control': 'no-cache',
-          'Connection': 'keep-alive',
-        })
-        setResHeaderStatus = true
+        streamResponse(res, qwenApiResponse.response, enable_thinking_flag, enable_web_search_flag);
       } else {
-        res.set({
-          'Content-Type': 'application/json',
-        })
-        setResHeaderStatus = true
+        notStreamResponse(res, qwenApiResponse.response, enable_thinking_flag, enable_web_search_flag, parsedModel);
       }
-    } catch (e) {
-      console.log(e)
+
+    } catch (error) { // 捕获顶层错误
+      console.error("处理聊天请求时发生未知严重错误 (router.post catch):", error);
+      // 安全地尝试发送错误响应给客户端
+      if (!res.headersSent) {
+        try { res.status(500).json({ error: `处理聊天请求时发生未知严重错误: ${error.message}` }); }
+        catch (e) { console.error("发送顶层错误响应失败:", e); }
+      } else if (res.writable && !res.writableEnded) {
+        try { const errorChunk = { id: `chatcmpl-${uuid.v4()}-internalerror`, object: "chat.completion.chunk", created: Date.now(), choices: [{ index: 0, delta: { content: `\n\n[内部服务器错误: ${error.message}]` }, finish_reason: "error" }] }; res.write(`data: ${JSON.stringify(errorChunk)}\n\n`); res.write(`data: [DONE]\n\n`); } catch (streamError) { console.error("写入内部错误到流失败:", streamError); }
+        finally { if (!res.writableEnded) res.end(); }
+      } else { console.error("无法向客户端发送内部错误响应。"); }
     }
   }
+);
 
-  try {
-    const response_data = await sendChatRequest(req.body)
-
-    if (response_data.status === !200 || !response_data.response) {
-      res.status(500)
-        .json({
-          error: "请求发送失败！！！"
-        })
-      return
-    }
-
-    if (stream) {
-      setResHeader(true)
-      streamResponse(res, response_data.response, enable_thinking, enable_web_search)
-    } else {
-      setResHeader(false)
-      notStreamResponse(res, response_data.response, enable_thinking, enable_web_search, model)
-    }
-
-  } catch (error) {
-    // console.log(error)
-    res.status(500)
-      .json({
-        error: "token无效,请求发送失败！！！"
-      })
-  }
-
-})
-
-module.exports = router
+module.exports = router;

--- a/src/router/file_upload.js
+++ b/src/router/file_upload.js
@@ -1,0 +1,59 @@
+// router/file_upload.js
+/**
+ * 处理文件上传至通义千问OSS，并返回文件URL。
+ */
+const express = require('express');
+const multer = require('multer');
+const router = express.Router();
+const { apiKeyVerify } = require('./index');
+const { uploadFileToQwenOss } = require('../lib/qwen_file_uploader');
+const accountManager = require('../lib/account');
+
+// Multer 配置: 内存存储，限制10MB
+const storage = multer.memoryStorage();
+const upload = multer({
+  storage: storage,
+  limits: { fileSize: 10 * 1024 * 1024 } // 限制为10MB
+});
+
+/**
+ * POST /v1/files/upload
+ * 上传单个文件 (multipart/form-data, 字段 "file")。
+ */
+router.post('/v1/files/upload', apiKeyVerify, upload.single('file'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ success: false, error: '未提供文件。请确保在 "file" 字段中包含文件。' });
+  }
+
+  try {
+    const fileBuffer = req.file.buffer;
+    const originalFilename = req.file.originalname;
+
+    const qwenAuthToken = accountManager.getAccountToken();
+    if (!qwenAuthToken) {
+      return res.status(500).json({ success: false, error: '无法获取通义千问认证Token。' });
+    }
+
+    const uploadResult = await uploadFileToQwenOss(fileBuffer, originalFilename, qwenAuthToken);
+
+    res.status(200).json({
+      success: true,
+      message: uploadResult.message,
+      url: uploadResult.file_url,
+      file_id: uploadResult.file_id,
+      filename: originalFilename,
+      size: req.file.size,
+      mimetype: req.file.mimetype
+    });
+
+  } catch (error) {
+    console.error('文件上传到Qwen OSS失败:', error); // 保留错误日志
+    let errorMessage = '文件上传失败。';
+    if (error.message) {
+      errorMessage = error.message;
+    }
+    res.status(500).json({ success: false, error: errorMessage });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
**1\. 新建文件：lib/qwen\_file\_uploader.js**

* **功能**：这个模块是实现图片上传到通义千问指定 OSS 的核心。  
* **详细职责**：  
  * requestStsToken 函数：负责向通义千问的 api/v1/files/getstsToken 端点发送请求，以获取上传到阿里云 OSS 所需的临时安全凭证（Access Key ID, Secret, STS Token）以及目标存储桶、路径等信息。  
  * uploadToOssWithSts 函数：接收文件内容 (Buffer形式)、STS 凭证和 OSS 信息，使用 ali-oss 这个 npm 库将文件实际上传到阿里云 OSS。  
  * uploadFileToQwenOss 函数：作为外部调用的主函数，它协调前两个步骤。接收文件 Buffer 和原始文件名，调用 requestStsToken 获取凭证，然后调用 uploadToOssWithSts 完成上传，并最终返回通义千问 API 所需的图片 CDN URL (file\_url) 和文件 ID (file\_id)。  
  * 还包含一些辅助函数，如从 MIME 类型获取简化文件类型。

**2\. 新建文件：router/file\_upload.js**

* **功能**：提供一个独立的 API 端点 (POST /v1/files/upload)，专门用于客户端预先上传图片文件。  
* **详细职责**：  
  * 使用 multer 中间件处理客户端发送的 multipart/form-data 请求，提取上传的文件（字段名为 file）。  
  * 获取通义千问的认证 Token (通过 accountManager)。  
  * 调用 lib/qwen\_file\_uploader.js 中的 uploadFileToQwenOss 函数，将接收到的文件上传到 OSS。  
  * 成功后，向客户端返回包含图片 CDN URL (url) 和文件 ID (file\_id) 的 JSON 响应。  
  * 此接口也受 apiKeyVerify 中间件保护。

**3\. 修改文件：router/chat.js**

* **功能**：这是聊天完成接口 (POST /v1/chat/completions) 的核心处理器，经过了大幅修改以支持图文混合输入。  
* **详细职责**：  
  * **支持多种 Content-Type**：能够智能判断并处理 application/json 和 multipart/form-data 两种类型的请求。  
  * **multipart/form-data 处理**：  
    * 使用 multer 提取通过表单字段 file 上传的图片文件，以及通过表单字段 messages (作为 JSON 字符串) 传递的文本消息和其他参数。  
    * 如果检测到图片文件，调用 lib/qwen\_file\_uploader.js 将其上传到 OSS 并获取 URL。  
  * **application/json 处理**：  
    * 直接解析 JSON 请求体。  
    * 检查 messages 数组中 content 字段是否包含 OpenAI 风格的 image\_url，且其 url 字段内容是 Base64 Data URI (data:image/...;base64,...)。  
    * 如果检测到 Base64 数据，提取数据、解码为 Buffer，然后调用 lib/qwen\_file\_uploader.js 将其上传到 OSS 并获取 URL。  
    * 将原始消息中的 Base64 URI 替换为获取到的 OSS URL。  
  * **消息构建**：无论是哪种输入方式，最终都会构建一个符合通义千问 API 要求的 messages 数组。如果包含图片，图片信息会以 { "type": "image", "image": "图片OSS的URL" } 的格式添加到用户消息的 content 数组中。  
  * **参数解析与传递**：正确解析和传递 model, stream, search, enable\_thinking 等参数。  
  * **错误处理增强**：对 messages 字段的解析（无论是来自 JSON 字符串还是直接的对象数组）做了更健壮的处理，以应对客户端可能发送的不同格式。修正了之前版本中因辅助函数缺失导致的 ReferenceError。  
  * 调用 lib/request.js 中的 sendChatRequest 将最终构建好的请求（包含文本和图片 URL）发送给通义千问。  
  * streamResponse 和 notStreamResponse 函数负责将通义千问的响应（流式或非流式）正确地转发给客户端。

**4\. 修改文件：lib/request.js**

* **功能**：封装向通义千问 API (chat.qwen.ai/api/chat/completions) 发送实际 HTTP 请求的逻辑。  
* **详细职责**：  
  * **错误处理增强**：显著改进了 axios.post 调用失败时的 catch 块逻辑。现在能更准确地识别和处理不同类型的错误，特别是网络连接错误（如 DNS 解析失败 EAI\_AGAIN）和 HTTP 错误状态码。  
  * 避免了因尝试访问未定义错误对象的属性（如 error.response.status）而导致的程序崩溃。  
  * 返回更结构化的错误信息给调用者 (router/chat.js)，包含了状态码、错误消息、可能的错误码 (code) 以及通义千问返回的原始错误数据（如果有）。  
  * 保留了对 429 Too Many Requests 状态码的重试逻辑。  
  * 增加了对模型名称的检查和默认值回退逻辑。

**5\. 修改文件：server.js**

* **功能**：Express 应用的主入口和服务器启动文件。  
* **详细职责**：  
  * **路由挂载**：引入并正确挂载了新建的 fileUploadRouter (app.use(fileUploadRouter))，使得 /v1/files/upload 接口能够被访问。  
  * **静态文件服务调整**：优化了服务前端管理页面静态文件的逻辑，使其路径计算更准确，并增加了日志记录和对 public/dist 目录是否存在的检查。