### PR TITLE
fix: 更新生图请求参数以兼容上游，返回普通聊天中生成的图片

### DIFF
--- a/src/controllers/chat.image.video.js
+++ b/src/controllers/chat.image.video.js
@@ -7,6 +7,54 @@ const { generateChatID } = require('../utils/request.js')
 const { getSsxmodItna, getSsxmodItna2 } = require('../utils/ssxmod-manager')
 const { getProxyAgent, getChatBaseUrl, applyProxyToAxiosConfig } = require('../utils/proxy-helper')
 
+const parseUpstreamImageError = (data) => {
+    try {
+        let payload = data
+
+        if (Array.isArray(payload) && payload.length > 0) {
+            payload = payload[0]
+        }
+
+        if (typeof payload === 'string') {
+            payload = JSON.parse(payload)
+        }
+
+        const errorData = payload?.data
+        if (!errorData) {
+            return null
+        }
+
+        if (errorData.code === 'RateLimited') {
+            const waitHours = errorData.num
+            logger.error(`图片/视频生成额度已用尽，需等待约 ${waitHours || '未知'} 小时`, 'CHAT')
+            return {
+                error: `当前账号的该功能使用次数已达上限。${waitHours ? `请等待约 ${waitHours} 小时后再试。` : ''}`,
+                code: errorData.code,
+                wait_hours: waitHours
+            }
+        }
+
+        return {
+            error: errorData.details || errorData.code || '服务错误，请稍后再试',
+            code: errorData.code
+        }
+    } catch (e) {
+        return null
+    }
+}
+
+const parseUpstreamImageErrorFromText = (text) => {
+    try {
+        if (!text || typeof text !== 'string') {
+            return null
+        }
+
+        return parseUpstreamImageError(JSON.parse(text))
+    } catch (e) {
+        return null
+    }
+}
+
 /**
  * 主要的聊天完成处理函数
  * @param {object} req - Express 请求对象
@@ -21,7 +69,9 @@ const handleImageVideoCompletion = async (req, res) => {
 
         // 请求体模板
         const reqBody = {
-            "stream": false,
+            "stream": true,
+            "version": "2.1",
+            "incremental_output": true,
             "chat_id": null,
             "model": model,
             "messages": [
@@ -129,16 +179,20 @@ const handleImageVideoCompletion = async (req, res) => {
         if (chat_type == 't2i' || chat_type == 't2v') {
             // 获取图片尺寸，优先级 参数 > 提示词 > 默认
             if (size != undefined && size != null) {
-                reqBody.size = "1:1"
-            } else if (_userPrompt.indexOf("@4:3") != -1) {
+                reqBody.size = size
+            } else if (typeof _userPrompt === 'string' && _userPrompt.indexOf("@4:3") != -1) {
                 reqBody.size = "4:3"//"1024*768"
-            } else if (_userPrompt.indexOf("@3:4") != -1) {
+            } else if (typeof _userPrompt === 'string' && _userPrompt.indexOf("@3:4") != -1) {
                 reqBody.size = "3:4"//"768*1024"
-            } else if (_userPrompt.indexOf("@16:9") != -1) {
+            } else if (typeof _userPrompt === 'string' && _userPrompt.indexOf("@16:9") != -1) {
                 reqBody.size = "16:9"//"1280*720"
-            } else if (_userPrompt.indexOf("@9:16") != -1) {
+            } else if (typeof _userPrompt === 'string' && _userPrompt.indexOf("@9:16") != -1) {
                 reqBody.size = "9:16"//"720*1280"
             }
+        }
+
+        if (chat_type == 't2v') {
+            reqBody.stream = false
         }
 
         const chatBaseUrl = getChatBaseUrl()
@@ -171,7 +225,7 @@ const handleImageVideoCompletion = async (req, res) => {
                 "Accept-Language": "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7",
                 "Cookie": `ssxmod_itna=${getSsxmodItna()};ssxmod_itna2=${getSsxmodItna2()}`,
             },
-            responseType: newChatType == 't2i' ? 'stream' : 'json',
+            responseType: newChatType == 't2v' ? 'json' : 'stream',
             timeout: 1000 * 60 * 5
         }
 
@@ -185,26 +239,46 @@ const handleImageVideoCompletion = async (req, res) => {
 
         try {
             let contentUrl = null
-            if (newChatType == 't2i') {
+            if (newChatType == 't2i' || newChatType == 'image_edit') {
                 const decoder = new TextDecoder('utf-8')
+                let buffer = ''
+                let rawText = ''
                 response_data.data.on('data', async (chunk) => {
-                    const data = decoder.decode(chunk, { stream: true }).split('\n').filter(item => item.trim() != "")
-                    console.log(data)
-                    for (const item of data) {
-                        const jsonObj = JSON.parse(item.replace("data:", '').trim())
-                        if (jsonObj && jsonObj.choices && jsonObj.choices[0] && jsonObj.choices[0].delta && jsonObj.choices[0].delta.content.trim() != "" && contentUrl == null) {
-                            contentUrl = jsonObj.choices[0].delta.content
+                    const decoded = decoder.decode(chunk, { stream: true })
+                    rawText += decoded
+                    buffer += decoded
+                    const events = buffer.split('\n\n')
+                    buffer = events.pop() || ''
+
+                    for (const event of events) {
+                        const dataLine = event.split('\n').find(item => item.trim().startsWith('data:'))
+                        if (!dataLine) {
+                            continue
+                        }
+
+                        const payload = dataLine.replace(/^data:\s*/, '').trim()
+                        if (!payload) {
+                            continue
+                        }
+
+                        try {
+                            const jsonObj = JSON.parse(payload)
+                            if (jsonObj && jsonObj.choices && jsonObj.choices[0] && jsonObj.choices[0].delta && typeof jsonObj.choices[0].delta.content === 'string' && jsonObj.choices[0].delta.content.trim() != "" && contentUrl == null) {
+                                contentUrl = jsonObj.choices[0].delta.content
+                            }
+                        } catch (e) {
+                            logger.error('图片SSE解析失败', 'CHAT', '', e)
                         }
                     }
                 })
 
                 response_data.data.on('end', () => {
+                    const upstreamError = parseUpstreamImageErrorFromText(rawText.trim())
+                    if (upstreamError) {
+                        return res.status(429).json(upstreamError)
+                    }
                     return returnResponse(res, model, contentUrl, req.body.stream)
                 })
-            } else if (newChatType == 'image_edit') {
-                console.log(response_data.data)
-                contentUrl = response_data.data?.data?.choices[0]?.message?.content[0]?.image
-                return returnResponse(res, model, contentUrl, req.body.stream)
             } else if (newChatType == 't2v') {
                 return handleVideoCompletion(req, res, response_data.data, token)
             }
@@ -215,6 +289,11 @@ const handleImageVideoCompletion = async (req, res) => {
         }
 
     } catch (error) {
+        const upstreamError = parseUpstreamImageError(error.response?.data)
+        if (upstreamError) {
+            return res.status(429).json(upstreamError)
+        }
+
         res.status(500).json({
             error: "服务错误，请稍后再试"
         })
@@ -256,6 +335,11 @@ const returnResponse = (res, model, contentUrl, stream) => {
 
 const handleVideoCompletion = async (req, res, response_data, token) => {
     try {
+        const upstreamError = parseUpstreamImageError(response_data)
+        if (upstreamError) {
+            return res.status(429).json(upstreamError)
+        }
+
         const videoTaskID = response_data?.data?.messages[0]?.extra?.wanx?.task_id
         if (!response_data || !response_data.success || !videoTaskID) {
             throw new Error()
@@ -283,6 +367,7 @@ const handleVideoCompletion = async (req, res, response_data, token) => {
         const maxAttempts = 60
         // 设置每次请求的间隔时间
         const delay = 20 * 1000
+        let headersInitialized = false
         // 循环尝试获取任务状态
         for (let i = 0; i < maxAttempts; i++) {
             const content = await getVideoTaskStatus(videoTaskID, token)
@@ -295,7 +380,10 @@ ${content}
 [Download Video](${content})
 `
                 // 设置响应头
-                setResponseHeaders(res, req.body.stream)
+                if (!headersInitialized && !res.headersSent) {
+                    setResponseHeaders(res, req.body.stream)
+                    headersInitialized = true
+                }
 
                 if (req.body.stream) {
                     res.write(`data: ${JSON.stringify(returnBody)}\n\n`)
@@ -307,6 +395,10 @@ ${content}
                 return
             } else if (content == null && req.body.stream) {
                 // 发送空数据保活
+                if (!headersInitialized && !res.headersSent) {
+                    setResponseHeaders(res, req.body.stream)
+                    headersInitialized = true
+                }
                 res.write(`data: ${JSON.stringify(returnBody)}\n\n`)
             }
 

--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -29,6 +29,20 @@ const setResponseHeaders = (res, stream) => {
     }
 }
 
+const getImageMarkdownListFromDelta = (delta) => {
+    // 常规聊天在触发 image_gen_tool 时，仅使用 image_list 中用于展示的图片链接
+    const imageList = []
+    const displayImages = delta?.extra?.image_list || []
+
+    for (const item of displayImages) {
+        if (item?.image) {
+            imageList.push(`![image](${item.image})`)
+        }
+    }
+
+    return imageList
+}
+
 /**
  * 处理流式响应
  * @param {object} res - Express 响应对象
@@ -45,6 +59,8 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
         let thinking_start = false
         let thinking_end = false
         let buffer = ''
+        let emittedImageMarkdownSet = new Set()
+        let pendingImageMarkdownList = []
 
         // Token消耗量统计
         let totalTokens = {
@@ -109,20 +125,58 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
                         }
                     }
 
+                    const delta = decodeJson.choices[0].delta
+
                     // 处理 web_search 信息
-                    if (decodeJson.choices[0].delta && decodeJson.choices[0].delta.name === 'web_search') {
-                        web_search_info = decodeJson.choices[0].delta.extra.web_search_info
+                    if (delta && delta.name === 'web_search') {
+                        web_search_info = delta.extra.web_search_info
                     }
 
-                    if (!decodeJson.choices[0].delta || !decodeJson.choices[0].delta.content ||
-                        (decodeJson.choices[0].delta.phase !== 'think' && decodeJson.choices[0].delta.phase !== 'answer')) {
+                    const imageMarkdownList = getImageMarkdownListFromDelta(delta)
+                    if (imageMarkdownList.length > 0) {
+                        const newImageMarkdownList = imageMarkdownList.filter(item => !emittedImageMarkdownSet.has(item))
+
+                        // 如果仍处于思考块内，则先缓存图片，等 </think> 输出后再插入，避免被客户端折叠
+                        if (thinking_start && !thinking_end) {
+                            for (const imageMarkdown of newImageMarkdownList) {
+                                if (!pendingImageMarkdownList.includes(imageMarkdown)) {
+                                    pendingImageMarkdownList.push(imageMarkdown)
+                                }
+                            }
+                        } else if (newImageMarkdownList.length > 0) {
+                            // 将图片工具结果转换成普通聊天内容，兼容下游仅识别 OpenAI 文本增量的场景
+                            const imageContent = `${newImageMarkdownList.join('\n\n')}\n\n`
+                            completionContent += imageContent
+                            newImageMarkdownList.forEach(item => emittedImageMarkdownSet.add(item))
+
+                            const streamImageTemplate = {
+                                "id": `chatcmpl-${message_id}`,
+                                "object": "chat.completion.chunk",
+                                "created": new Date().getTime(),
+                                "choices": [
+                                    {
+                                        "index": 0,
+                                        "delta": {
+                                            "content": imageContent
+                                        },
+                                        "finish_reason": null
+                                    }
+                                ]
+                            }
+
+                            res.write(`data: ${JSON.stringify(streamImageTemplate)}\n\n`)
+                        }
+                    }
+
+                    if (!delta || !delta.content ||
+                        (delta.phase !== 'think' && delta.phase !== 'answer')) {
                         continue
                     }
 
-                    let content = decodeJson.choices[0].delta.content
-                    completionContent += content // 累计完整内容用于token估算
+                    let content = delta.content
+                    completionContent += content // 累计完整的回复内容用于token估算
 
-                    if (decodeJson.choices[0].delta.phase === 'think' && !thinking_start) {
+                    if (delta.phase === 'think' && !thinking_start) {
                         thinking_start = true
                         if (web_search_info) {
                             content = `<think>\n\n${await accountManager.generateMarkdownTable(web_search_info, config.searchInfoMode)}\n\n${content}`
@@ -130,9 +184,17 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
                             content = `<think>\n\n${content}`
                         }
                     }
-                    if (decodeJson.choices[0].delta.phase === 'answer' && !thinking_end && thinking_start) {
+                    if (delta.phase === 'answer' && !thinking_end && thinking_start) {
                         thinking_end = true
-                        content = `\n\n</think>\n${content}`
+                        if (pendingImageMarkdownList.length > 0) {
+                            const pendingImageContent = `${pendingImageMarkdownList.join('\n\n')}\n\n`
+                            content = `\n\n</think>\n${pendingImageContent}${content}`
+                            completionContent += pendingImageContent
+                            pendingImageMarkdownList.forEach(item => emittedImageMarkdownSet.add(item))
+                            pendingImageMarkdownList = []
+                        } else {
+                            content = `\n\n</think>\n${content}`
+                        }
                     }
 
                     const StreamTemplate = {
@@ -246,6 +308,8 @@ const handleNonStreamResponse = async (res, response, enable_thinking, enable_we
         let web_search_info = null
         let thinking_start = false
         let thinking_end = false
+        let appendedImageMarkdownSet = new Set()
+        let pendingImageMarkdownList = []
 
         // Token消耗量统计
         let totalTokens = {
@@ -310,20 +374,40 @@ const handleNonStreamResponse = async (res, response, enable_thinking, enable_we
                             }
                         }
 
+                        const delta = decodeJson.choices[0].delta
+
                         // 处理 web_search 信息
-                        if (decodeJson.choices[0].delta && decodeJson.choices[0].delta.name === 'web_search') {
-                            web_search_info = decodeJson.choices[0].delta.extra.web_search_info
+                        if (delta && delta.name === 'web_search') {
+                            web_search_info = delta.extra.web_search_info
                         }
 
-                        if (!decodeJson.choices[0].delta || !decodeJson.choices[0].delta.content ||
-                            (decodeJson.choices[0].delta.phase !== 'think' && decodeJson.choices[0].delta.phase !== 'answer')) {
+                        const imageMarkdownList = getImageMarkdownListFromDelta(delta)
+                        if (imageMarkdownList.length > 0) {
+                            const newImageMarkdownList = imageMarkdownList.filter(item => !appendedImageMarkdownSet.has(item))
+
+                            // 非流式模式下如果仍处于思考块内，则延后到 </think> 后再追加图片
+                            if (thinking_start && !thinking_end) {
+                                for (const imageMarkdown of newImageMarkdownList) {
+                                    if (!pendingImageMarkdownList.includes(imageMarkdown)) {
+                                        pendingImageMarkdownList.push(imageMarkdown)
+                                    }
+                                }
+                            } else if (newImageMarkdownList.length > 0) {
+                                // 非流式模式下同样追加 Markdown 图片链接，保持与现有图片返回格式一致
+                                fullContent += `${newImageMarkdownList.join('\n\n')}\n\n`
+                                newImageMarkdownList.forEach(item => appendedImageMarkdownSet.add(item))
+                            }
+                        }
+
+                        if (!delta || !delta.content ||
+                            (delta.phase !== 'think' && delta.phase !== 'answer')) {
                             continue
                         }
 
-                        let content = decodeJson.choices[0].delta.content
+                        let content = delta.content
 
                         // 处理thinking模式
-                        if (decodeJson.choices[0].delta.phase === 'think' && !thinking_start) {
+                        if (delta.phase === 'think' && !thinking_start) {
                             thinking_start = true
                             if (web_search_info) {
                                 const webSearchTable = await accountManager.generateMarkdownTable(web_search_info, config.searchInfoMode)
@@ -332,9 +416,15 @@ const handleNonStreamResponse = async (res, response, enable_thinking, enable_we
                                 content = `<think>\n\n${content}`
                             }
                         }
-                        if (decodeJson.choices[0].delta.phase === 'answer' && !thinking_end && thinking_start) {
+                        if (delta.phase === 'answer' && !thinking_end && thinking_start) {
                             thinking_end = true
-                            content = `\n\n</think>\n${content}`
+                            if (pendingImageMarkdownList.length > 0) {
+                                content = `\n\n</think>\n${pendingImageMarkdownList.join('\n\n')}\n\n${content}`
+                                pendingImageMarkdownList.forEach(item => appendedImageMarkdownSet.add(item))
+                                pendingImageMarkdownList = []
+                            } else {
+                                content = `\n\n</think>\n${content}`
+                            }
                         }
 
                         fullContent += content


### PR DESCRIPTION
您好，首先感谢您的这一优秀项目！
项目的生图功能之前似乎一直有问题，总是提示 `Bad_Request` 。经过在浏览器中测试，发现生图/改图部分需要将上游参数中的 `stream` 设置为 `true` ，并添加 `version` 和 `incremental_output` 参数才能正确请求，因此我在 `chat.image.video.js` 中添加了上述三个请求参数。由于我对nodejs不是很了解，因此又根据GPT的建议，修改了对应的响应解析代码。另外，根据GPT的另一建议，我添加了当生图/生视频额度用尽时，向用户返回具体等待时长的功能。
同时我注意到，即使用户使用普通的文本聊天模式时，如果用户请求生成或输出图片，AI也会相应调用 `image_gen` 工具并在输出中插入一张或多张图片。因此，我在 `chat.js` 中添加了向用户返回图片链接 `![image](https://example.com/image.png)` 的功能。若AI通过response，返回这些图片链接，则会在正文（如果在深度思考时上游返回链接，则在思考结束后再一起插入正文）中插入它们。
修改完成后，我分别使用curl和RikkaHub进行了测试，没有新的异常。
整个过程中，我尽量少地改动代码，以确保修复问题和实现功能的同时，尽量不引入其他问题。如果有问题需要继续修改，还请您说明，我会在修改后重新提交。
谢谢！