### PR TITLE
fix：流式响应对象中的created改为10位时间戳

### DIFF
--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -152,7 +152,7 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
                             const streamImageTemplate = {
                                 "id": `chatcmpl-${message_id}`,
                                 "object": "chat.completion.chunk",
-                                "created": new Date().getTime(),
+                                "created": Math.round(new Date().getTime() / 1000),
                                 "choices": [
                                     {
                                         "index": 0,
@@ -200,7 +200,7 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
                     const StreamTemplate = {
                         "id": `chatcmpl-${message_id}`,
                         "object": "chat.completion.chunk",
-                        "created": new Date().getTime(),
+                        "created": Math.round(new Date().getTime() / 1000),
                         "choices": [
                             {
                                 "index": 0,
@@ -228,7 +228,7 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
                     res.write(`data: ${JSON.stringify({
                         "id": `chatcmpl-${message_id}`,
                         "object": "chat.completion.chunk",
-                        "created": new Date().getTime(),
+                        "created": Math.round(new Date().getTime() / 1000),
                         "choices": [
                             {
                                 "index": 0,
@@ -258,7 +258,7 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
                 res.write(`data: ${JSON.stringify({
                     "id": `chatcmpl-${message_id}`,
                     "object": "chat.completion.chunk",
-                    "created": new Date().getTime(),
+                    "created": Math.round(new Date().getTime() / 1000),
                     "choices": [
                         {
                             "index": 0,
@@ -272,7 +272,7 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
                 res.write(`data: ${JSON.stringify({
                     "id": `chatcmpl-${message_id}`,
                     "object": "chat.completion.chunk",
-                    "created": new Date().getTime(),
+                    "created": Math.round(new Date().getTime() / 1000),
                     "choices": [],
                     "usage": totalTokens
                 })}\n\n`)
@@ -467,7 +467,7 @@ const handleNonStreamResponse = async (res, response, enable_thinking, enable_we
         const bodyTemplate = {
             "id": `chatcmpl-${generateUUID()}`,
             "object": "chat.completion",
-            "created": new Date().getTime(),
+            "created": Math.round(new Date().getTime() / 1000),
             "model": model,
             "choices": [
                 {


### PR DESCRIPTION
当前返回对象中 "created": new Date().getTime() 为13位时间戳 （毫秒）不符合标准OpenAI规范，改为标准的10位时间戳（秒）
13位时间戳在一些开发框架（Microsoft.Agent.AI）中会报错Valid values are between -62135596800 and 253402300799, inclusive. (Parameter 'seconds')


