### PR TITLE
i18n(backend): localize Chinese error responses to English

### DIFF
--- a/src/controllers/anthropic.js
+++ b/src/controllers/anthropic.js
@@ -641,7 +641,7 @@ const handleAnthropicMessages = async (req, res) => {
     if (!res.headersSent) {
       res.status(500).json({
         type: 'error',
-        error: { type: 'api_error', message: '服务错误' }
+        error: { type: 'api_error', message: 'Service error' }
       });
     } else {
       try { res.end(); } catch (_) { /* ignore */ }

--- a/src/controllers/anthropic.js
+++ b/src/controllers/anthropic.js
@@ -624,7 +624,7 @@ const handleAnthropicMessages = async (req, res) => {
     if (!upstreamResp.status || !upstreamResp.response) {
       return res.status(500).json({
         type: 'error',
-        error: { type: 'api_error', message: '请求发送失败' }
+        error: { type: 'api_error', message: 'Request failed' }
       });
     }
 

--- a/src/controllers/chat.image.video.js
+++ b/src/controllers/chat.image.video.js
@@ -128,7 +128,7 @@ const parseUpstreamImageError = (data) => {
             raw_response_body: rawPayload
         })
         return {
-            error: errorData.details || errorData.code || '服务错误，请稍后再试',
+            error: errorData.details || errorData.code || 'Service error, please try again later',
             code: errorData.code,
             request_id: payload.request_id,
             status: errorData.code === 'Bad_Request' && /internal error/i.test(errorData.details || '') ? 502 : 500
@@ -648,7 +648,7 @@ const normalizeOpenAIImageVideoSize = (size) => {
  */
 const sendOpenAIErrorResponse = (res, error) => {
     const status = error?.status || 500
-    const message = error?.error || error?.message || '服务错误，请稍后再试'
+    const message = error?.error || error?.message || 'Service error, please try again later'
 
     return res.status(status).json({
         error: {
@@ -1467,7 +1467,7 @@ const generateImageVideoResult = async (payload) => {
 
         throw {
             status: 500,
-            error: error?.message || '服务错误，请稍后再试'
+            error: error?.message || 'Service error, please try again later'
         }
     }
 }
@@ -1506,12 +1506,12 @@ const handleImageVideoCompletion = async (req, res) => {
         logger.error('图片视频资源处理错误', 'CHAT', '', error)
 
         if (downstreamStream) {
-            return returnResponse(res, req.body.model, error?.error || error?.message || '服务错误，请稍后再试', true)
+            return returnResponse(res, req.body.model, error?.error || error?.message || 'Service error, please try again later', true)
         }
 
         return sendUpstreamError(res, error?.error ? error : {
             status: 500,
-            error: error?.message || '服务错误，请稍后再试'
+            error: error?.message || 'Service error, please try again later'
         })
     }
 }

--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -395,7 +395,7 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
         res.end()
     } catch (error) {
         logger.error('聊天处理错误', 'CHAT', '', error)
-        try { res.status(500).json({ error: "服务错误!!!" }) } catch (_) { /* response already started */ }
+        try { res.status(500).json({ error: "Service error" }) } catch (_) { /* response already started */ }
     }
 }
 
@@ -632,7 +632,7 @@ const handleNonStreamResponse = async (res, response, enable_thinking, enable_we
         logger.error('非流式聊天处理错误', 'CHAT', '', error)
         res.status(500)
             .json({
-                error: "服务错误!!!"
+                error: "Service error"
             })
     }
 }

--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -655,7 +655,7 @@ const handleChatCompletion = async (req, res) => {
         if (!response_data.status || !response_data.response) {
             res.status(500)
                 .json({
-                    error: "请求发送失败！！！"
+                    error: "Request failed"
                 })
             return
         }
@@ -672,7 +672,7 @@ const handleChatCompletion = async (req, res) => {
         logger.error('聊天处理错误', 'CHAT', '', error)
         res.status(500)
             .json({
-                error: "token无效,请求发送失败！！！"
+                error: "Invalid token, request failed"
             })
     }
 }


### PR DESCRIPTION
你好！我非常喜欢这个项目，忍不住想再做一点小贡献 🌸

## 改动

本 PR 将 backend 返回给 API 客户端的 11 处中文错误字面量替换为简洁的英文，方便非中文开发者在客户端侧排查问题。

修改范围（`src/controllers/`）：

- `chat.js`（× 4）：
  - `'请求发送失败！！！'` → `'Request failed'`
  - `'token无效,请求发送失败！！！'` → `'Invalid token, request failed'`
  - `'服务错误!!!'` → `'Service error'`（× 2）
- `chat.image.video.js`（× 5）：
  - `'服务错误，请稍后再试'` → `'Service error, please try again later'`
- `anthropic.js`（× 2）：
  - `'请求发送失败'` → `'Request failed'`
  - `'服务错误'` → `'Service error'`

## 风格

沿用 `src/middlewares/authorization.js` 中已有的英文风格（`'Unauthorized'`、`'Admin access required'`）——简洁、无尾标点。

## 向后兼容

仅替换错误响应中的 `message` / `error` 字符串字面量，未改动：

- HTTP 状态码
- 响应结构（字段名、嵌套）
- 错误处理流程
- 日志输出（`logger.error` 调用中的中文标签保持不变）

非常感谢您维护这个出色的项目！🙏

<details>
<summary>English version</summary>

Hello! I really like this project and couldn't deny myself the pleasure of making one more small contribution 🌸

## Changes

This PR replaces 11 hardcoded Chinese error literals in the backend with concise English, making API error responses easier to handle for non-Chinese-speaking developers.

Scope (`src/controllers/`):

- `chat.js` (× 4):
  - `'请求发送失败！！！'` → `'Request failed'`
  - `'token无效,请求发送失败！！！'` → `'Invalid token, request failed'`
  - `'服务错误!!!'` → `'Service error'` (× 2)
- `chat.image.video.js` (× 5):
  - `'服务错误，请稍后再试'` → `'Service error, please try again later'`
- `anthropic.js` (× 2):
  - `'请求发送失败'` → `'Request failed'`
  - `'服务错误'` → `'Service error'`

## Style

Follows the existing English style in `src/middlewares/authorization.js` (`'Unauthorized'`, `'Admin access required'`) — concise, no trailing punctuation.

## Backward compatibility

Only `message` / `error` string literals in error responses are replaced. Unchanged:

- HTTP status codes
- Response shape (field names, nesting)
- Error handling flow
- Logging output (Chinese tags in `logger.error` calls are preserved)

Thanks for maintaining this excellent project! 🙏

</details>