### PR TITLE
feat: 账户级统计 + dashboard UI + CLI init 不阻塞 chat-flow

### DIFF
--- a/public/src/locales/ru.json
+++ b/public/src/locales/ru.json
@@ -59,7 +59,13 @@
     "editProxyTitle": "Изменить proxy",
     "editProxyHint": "Оставьте пустым, чтобы очистить и использовать глобальный PROXY_URL",
     "clearProxy": "Очистить",
-    "save": "Сохранить"
+    "save": "Сохранить",
+    "acct": {
+      "chatToday": "Chat (сегодня)",
+      "cliToday": "CLI (сегодня)",
+      "calls": "запросов",
+      "cliSuccess": "успешно"
+    }
   },
   "msg": {
     "batchComplete": "Добавление завершено: успешно {n}",

--- a/public/src/locales/ru.json
+++ b/public/src/locales/ru.json
@@ -64,7 +64,16 @@
       "chatToday": "Chat (сегодня)",
       "cliToday": "CLI (сегодня)",
       "calls": "запросов",
-      "cliSuccess": "успешно"
+      "cliSuccess": "успешно",
+      "status": {
+        "active": "Активен",
+        "warn": "Недавние ошибки ({code}, {ago} назад)",
+        "warnNoCode": "Недавние ошибки ({ago} назад)",
+        "cooldown": "В охлаждении (осталось {until})",
+        "tokenExpiring": "Токен скоро истекает",
+        "unitSec": "сек",
+        "unitMin": "мин"
+      }
     }
   },
   "msg": {

--- a/public/src/locales/ru.json
+++ b/public/src/locales/ru.json
@@ -65,6 +65,8 @@
       "cliToday": "CLI (сегодня)",
       "calls": "запросов",
       "cliSuccess": "успешно",
+      "unitK": "к",
+      "unitM": "M",
       "status": {
         "active": "Активен",
         "warn": "Недавние ошибки ({code}, {ago} назад)",

--- a/public/src/locales/zh.json
+++ b/public/src/locales/zh.json
@@ -59,7 +59,13 @@
     "editProxyTitle": "修改代理",
     "editProxyHint": "留空将清除该账号代理，回退到全局 PROXY_URL",
     "clearProxy": "清除",
-    "save": "保存"
+    "save": "保存",
+    "acct": {
+      "chatToday": "今日 Chat",
+      "cliToday": "今日 CLI",
+      "calls": "次调用",
+      "cliSuccess": "成功"
+    }
   },
   "msg": {
     "batchComplete": "批量添加完成: 成功{n}个",

--- a/public/src/locales/zh.json
+++ b/public/src/locales/zh.json
@@ -64,7 +64,16 @@
       "chatToday": "今日 Chat",
       "cliToday": "今日 CLI",
       "calls": "次调用",
-      "cliSuccess": "成功"
+      "cliSuccess": "成功",
+      "status": {
+        "active": "活跃",
+        "warn": "最近有错误 ({code}, {ago}前)",
+        "warnNoCode": "最近有错误 ({ago}前)",
+        "cooldown": "冷却中 (剩余 {until})",
+        "tokenExpiring": "Token 即将过期",
+        "unitSec": "秒",
+        "unitMin": "分"
+      }
     }
   },
   "msg": {

--- a/public/src/locales/zh.json
+++ b/public/src/locales/zh.json
@@ -65,6 +65,8 @@
       "cliToday": "今日 CLI",
       "calls": "次调用",
       "cliSuccess": "成功",
+      "unitK": "k",
+      "unitM": "M",
       "status": {
         "active": "活跃",
         "warn": "最近有错误 ({code}, {ago}前)",

--- a/public/src/views/dashboard.vue
+++ b/public/src/views/dashboard.vue
@@ -140,7 +140,10 @@
           <div v-for="token in displayedTokens"
                :key="token.email"
                class="token-card group relative overflow-hidden rounded-2xl transition-all duration-300 hover:shadow-2xl pt-4"
-               :class="{'ring-2 ring-indigo-500 ring-opacity-75': isSelected(token.email)}">
+               :class="[
+                 { 'ring-2 ring-indigo-500 ring-opacity-75': isSelected(token.email) },
+                 { 'opacity-60 grayscale': isOnCooldown(token.email) }
+               ]">
             <div class="absolute top-3 left-3 z-10">
               <label class="custom-checkbox cursor-pointer">
                 <input type="checkbox"
@@ -153,6 +156,12 @@
                   </svg>
                 </div>
               </label>
+            </div>
+            <div class="absolute top-3 right-3 z-10 flex items-center gap-1 text-lg leading-none select-none"
+                 :title="getStatusTooltip(token.email)">
+              <span>{{ getStatusEmoji(token.email) }}</span>
+              <span v-if="isOnCooldown(token.email)"
+                    class="text-sm font-mono text-gray-700">{{ getCountdown(token.email) }}</span>
             </div>
             <div class="absolute inset-0 bg-white/30 backdrop-blur-md border border-white/30"></div>
             <div class="relative p-6 flex flex-col gap-4">
@@ -494,7 +503,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import axios from 'axios'
 import LangSwitcher from '../components/LangSwitcher.vue'
@@ -570,6 +579,64 @@ const getCliProgressColor = (email) => {
   return 'bg-emerald-500'
 }
 
+// Per-account status indicator (Qwen2API-3wg.3)
+const STATUS_EMOJI = Object.freeze({
+  active: '🟢',
+  warn: '🟡',
+  cooldown: '🔴',
+  token_expiring: '🪫'
+})
+const nowTick = ref(Date.now())
+let tickInterval = null
+// Map<email, cooldownEndsAt> — refetch suppression per-account.
+// Single global flag would block refetch for other accounts after first expiry.
+const cooldownRefetched = new Map()
+
+const getStatusKind = (email) => accountStats.value[email]?.status?.kind || 'active'
+const getStatusEmoji = (email) => STATUS_EMOJI[getStatusKind(email)] || STATUS_EMOJI.active
+const isOnCooldown = (email) => {
+  const s = accountStats.value[email]?.status
+  return s?.kind === 'cooldown' && typeof s?.cooldownEndsAt === 'number'
+}
+
+const formatAgo = (ms) => {
+  const sec = Math.max(0, Math.floor(ms / 1000))
+  if (sec < 60) return `${sec} ${t('dash.acct.status.unitSec')}`
+  return `${Math.floor(sec / 60)} ${t('dash.acct.status.unitMin')}`
+}
+
+const formatCountdown = (ms) => {
+  const sec = Math.max(0, Math.floor(ms / 1000))
+  const mm = String(Math.floor(sec / 60)).padStart(2, '0')
+  const ss = String(sec % 60).padStart(2, '0')
+  return `${mm}:${ss}`
+}
+
+const getCountdown = (email) => {
+  const s = accountStats.value[email]?.status
+  if (s?.kind !== 'cooldown' || typeof s?.cooldownEndsAt !== 'number') return ''
+  return formatCountdown(s.cooldownEndsAt - nowTick.value)
+}
+
+const getStatusTooltip = (email) => {
+  const s = accountStats.value[email]?.status
+  const kind = s?.kind || 'active'
+  if (kind === 'cooldown' && typeof s?.cooldownEndsAt === 'number') {
+    return t('dash.acct.status.cooldown', { until: formatCountdown(s.cooldownEndsAt - nowTick.value) })
+  }
+  if (kind === 'warn') {
+    const ago = typeof s?.lastErrorAt === 'number' ? formatAgo(nowTick.value - s.lastErrorAt) : ''
+    if (s?.lastErrorCode !== null && s?.lastErrorCode !== undefined && s?.lastErrorCode !== '') {
+      return t('dash.acct.status.warn', { code: s.lastErrorCode, ago })
+    }
+    return t('dash.acct.status.warnNoCode', { ago })
+  }
+  if (kind === 'token_expiring') {
+    return t('dash.acct.status.tokenExpiring')
+  }
+  return t('dash.acct.status.active')
+}
+
 const fetchAccountStats = async () => {
   try {
     const res = await axios.get('/api/accountStats', {
@@ -583,10 +650,35 @@ const fetchAccountStats = async () => {
     if (typeof res.data?.cliQuotaLimit === 'number' && res.data.cliQuotaLimit > 0) {
       cliQuotaLimit.value = res.data.cliQuotaLimit
     }
+    // Drop suppression entries where account is no longer in cooldown OR
+    // cooldownEndsAt changed (new cooldown cycle → must allow refetch again).
+    for (const [email, cachedEndsAt] of cooldownRefetched) {
+      const s = map[email]?.status
+      if (s?.kind !== 'cooldown' || s?.cooldownEndsAt !== cachedEndsAt) {
+        cooldownRefetched.delete(email)
+      }
+    }
   } catch (error) {
     console.error('fetchAccountStats error:', error)
   }
 }
+
+// Auto-refetch when any account's cooldown expires (per-account suppression via Map).
+// Marks every expired-but-not-yet-refetched account in the suppression Map, then
+// fires a single fetchAccountStats (one call refreshes status for all accounts).
+watch([nowTick, accountStats], () => {
+  const stats = accountStats.value
+  let shouldRefetch = false
+  for (const email of Object.keys(stats)) {
+    const s = stats[email]?.status
+    if (s?.kind !== 'cooldown' || typeof s?.cooldownEndsAt !== 'number') continue
+    if (nowTick.value >= s.cooldownEndsAt && cooldownRefetched.get(email) !== s.cooldownEndsAt) {
+      cooldownRefetched.set(email, s.cooldownEndsAt)
+      shouldRefetch = true
+    }
+  }
+  if (shouldRefetch) fetchAccountStats()
+})
 
 // Toast 通知
 const toast = ref({
@@ -1064,6 +1156,8 @@ onMounted(() => {
   getTokens()
   fetchAccountStats()
   statsInterval.value = setInterval(fetchAccountStats, 30000)
+  // 1s tick drives countdown rerender and cooldown-expiry watcher.
+  tickInterval = setInterval(() => { nowTick.value = Date.now() }, 1000)
 })
 
 onBeforeUnmount(() => {
@@ -1071,6 +1165,10 @@ onBeforeUnmount(() => {
   if (statsInterval.value) {
     clearInterval(statsInterval.value)
     statsInterval.value = null
+  }
+  if (tickInterval) {
+    clearInterval(tickInterval)
+    tickInterval = null
   }
 })
 </script>

--- a/public/src/views/dashboard.vue
+++ b/public/src/views/dashboard.vue
@@ -194,32 +194,58 @@
                 </div>
               </div>
 
-              <div class="pt-4 mt-auto border-t border-gray-200/50 space-y-2">
-                <button @click="openEditProxy(token)"
-                        class="w-full py-2 rounded-lg transition-all duration-300 bg-indigo-50 text-indigo-700 hover:bg-indigo-100 border border-indigo-200">
-                  {{ t('dash.editProxy') }}
-                </button>
-                <button @click="refreshToken(token.email)"
-                        :disabled="refreshingTokens.includes(token.email)"
-                        :class="[
-                          'w-full py-2 rounded-lg transition-all duration-300 flex items-center justify-center space-x-2',
-                          refreshingTokens.includes(token.email)
-                            ? 'bg-green-400 text-white refreshing-button-green cursor-not-allowed'
-                            : 'macaron-green-button text-green-600 hover:bg-green-100 border border-green-200'
-                        ]">
-                  <span v-if="refreshingTokens.includes(token.email)" class="flex items-center space-x-2">
-                    <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                      <path class="opacity-75" fill="currentColor" d="m4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                    </svg>
-                    <span>{{ t('dash.refreshing') }}</span>
+              <div class="bg-white/40 backdrop-blur-sm border border-white/40 rounded-2xl px-4 py-3 text-sm space-y-1 transition-all">
+                <div class="flex items-baseline justify-between gap-2">
+                  <span class="text-gray-600">{{ t('dash.acct.chatToday') }}:</span>
+                  <span class="font-medium text-gray-800 text-xs md:text-sm">
+                    {{ getAccountStats(token.email).chat.input }} in / {{ getAccountStats(token.email).chat.output }} out
                   </span>
-                  <span v-else>{{ t('dash.refreshToken') }}</span>
-                </button>
-                <button @click="deleteToken(token.email)"
-                        class="w-full group-hover:bg-red-50 text-red-600 py-2 rounded-lg transition-all duration-300 hover:bg-red-100">
-                  {{ t('dash.deleteAccount') }}
-                </button>
+                </div>
+                <div class="flex items-baseline justify-between gap-2">
+                  <span class="text-gray-600">{{ t('dash.acct.cliToday') }}:</span>
+                  <span class="font-medium text-gray-800 text-xs md:text-sm">
+                    {{ getCliRequestNumber(token.email) }} / {{ cliQuotaLimit }} {{ t('dash.acct.calls') }}
+                    <span class="text-xs opacity-60">({{ t('dash.acct.cliSuccess') }}: {{ getAccountStats(token.email).cli.calls }})</span>
+                  </span>
+                </div>
+                <div class="h-2 bg-gray-200/60 rounded-full overflow-hidden">
+                  <div :style="{ width: getCliProgressPct(token.email) + '%' }"
+                       :class="getCliProgressColor(token.email)"
+                       class="h-full transition-all duration-300"></div>
+                </div>
+                <div class="text-xs text-gray-500 text-right">
+                  {{ getAccountStats(token.email).cli.input }} in / {{ getAccountStats(token.email).cli.output }} out
+                </div>
+              </div>
+
+              <div class="pt-4 mt-auto border-t border-gray-200/50">
+                <div class="flex flex-row gap-2">
+                  <button @click="openEditProxy(token)"
+                          class="flex-1 py-2 px-2 rounded-lg transition-all duration-300 bg-indigo-50 text-indigo-700 hover:bg-indigo-100 border border-indigo-200 text-xs md:text-sm">
+                    {{ t('dash.editProxy') }}
+                  </button>
+                  <button @click="refreshToken(token.email)"
+                          :disabled="refreshingTokens.includes(token.email)"
+                          :class="[
+                            'flex-1 py-2 px-2 rounded-lg transition-all duration-300 flex items-center justify-center gap-1 text-xs md:text-sm',
+                            refreshingTokens.includes(token.email)
+                              ? 'bg-green-400 text-white refreshing-button-green cursor-not-allowed'
+                              : 'macaron-green-button text-green-600 hover:bg-green-100 border border-green-200'
+                          ]">
+                    <span v-if="refreshingTokens.includes(token.email)" class="flex items-center gap-1">
+                      <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="m4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                      <span>{{ t('dash.refreshing') }}</span>
+                    </span>
+                    <span v-else>{{ t('dash.refreshToken') }}</span>
+                  </button>
+                  <button @click="deleteToken(token.email)"
+                          class="flex-1 py-2 px-2 rounded-lg border border-red-200 text-red-600 group-hover:bg-red-50 transition-all duration-300 hover:bg-red-100 text-xs md:text-sm">
+                    {{ t('dash.deleteAccount') }}
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -521,6 +547,46 @@ const showDeleteAllConfirm = ref(false)
 const isRefreshingAll = ref(false)
 const isForceRefreshingAll = ref(false)
 const refreshingTokens = ref([])
+
+// Per-account stats (Qwen2API-3wg.2)
+const accountStats = ref({})
+const statsInterval = ref(null)
+const cliQuotaLimit = ref(2000)
+const DEFAULT_STATS = Object.freeze({
+  chat: { input: 0, output: 0 },
+  cli: { calls: 0, input: 0, output: 0 }
+})
+
+const getAccountStats = (email) => accountStats.value[email]?.stats || DEFAULT_STATS
+const getCliRequestNumber = (email) => accountStats.value[email]?.cliRequestNumber || 0
+const getCliProgressPct = (email) => {
+  const limit = cliQuotaLimit.value || 2000
+  return Math.min(100, getCliRequestNumber(email) / limit * 100)
+}
+const getCliProgressColor = (email) => {
+  const pct = getCliProgressPct(email)
+  if (pct >= 80) return 'bg-red-500'
+  if (pct >= 50) return 'bg-amber-500'
+  return 'bg-emerald-500'
+}
+
+const fetchAccountStats = async () => {
+  try {
+    const res = await axios.get('/api/accountStats', {
+      headers: getAuthHeaders()
+    })
+    const map = {}
+    for (const entry of res.data?.accounts || []) {
+      if (entry?.email) map[entry.email] = entry
+    }
+    accountStats.value = map
+    if (typeof res.data?.cliQuotaLimit === 'number' && res.data.cliQuotaLimit > 0) {
+      cliQuotaLimit.value = res.data.cliQuotaLimit
+    }
+  } catch (error) {
+    console.error('fetchAccountStats error:', error)
+  }
+}
 
 // Toast 通知
 const toast = ref({
@@ -996,10 +1062,16 @@ const exportAccounts = async () => {
 
 onMounted(() => {
   getTokens()
+  fetchAccountStats()
+  statsInterval.value = setInterval(fetchAccountStats, 30000)
 })
 
 onBeforeUnmount(() => {
   clearBatchTaskPolling()
+  if (statsInterval.value) {
+    clearInterval(statsInterval.value)
+    statsInterval.value = null
+  }
 })
 </script>
 

--- a/public/src/views/dashboard.vue
+++ b/public/src/views/dashboard.vue
@@ -207,24 +207,41 @@
                 <div class="flex items-baseline justify-between gap-2">
                   <span class="text-gray-600">{{ t('dash.acct.chatToday') }}:</span>
                   <span class="font-medium text-gray-800 text-xs md:text-sm">
-                    {{ getAccountStats(token.email).chat.input }} in / {{ getAccountStats(token.email).chat.output }} out
+                    <span :title="String(getAccountStats(token.email).chat.input)">{{ formatCompact(getAccountStats(token.email).chat.input) }}</span>
+                    in /
+                    <span :title="String(getAccountStats(token.email).chat.output)">{{ formatCompact(getAccountStats(token.email).chat.output) }}</span>
+                    out
                   </span>
                 </div>
-                <div class="flex items-baseline justify-between gap-2">
-                  <span class="text-gray-600">{{ t('dash.acct.cliToday') }}:</span>
-                  <span class="font-medium text-gray-800 text-xs md:text-sm">
-                    {{ getCliRequestNumber(token.email) }} / {{ cliQuotaLimit }} {{ t('dash.acct.calls') }}
-                    <span class="text-xs opacity-60">({{ t('dash.acct.cliSuccess') }}: {{ getAccountStats(token.email).cli.calls }})</span>
+                <button type="button"
+                        @click="toggleCliExpanded"
+                        class="flex items-baseline justify-between gap-2 w-full text-left focus:outline-none">
+                  <span class="text-gray-600 border-b border-dotted border-gray-400 hover:text-gray-800 transition-colors">
+                    {{ t('dash.acct.cliToday') }}:
                   </span>
-                </div>
-                <div class="h-2 bg-gray-200/60 rounded-full overflow-hidden">
-                  <div :style="{ width: getCliProgressPct(token.email) + '%' }"
-                       :class="getCliProgressColor(token.email)"
-                       class="h-full transition-all duration-300"></div>
-                </div>
-                <div class="text-xs text-gray-500 text-right">
-                  {{ getAccountStats(token.email).cli.input }} in / {{ getAccountStats(token.email).cli.output }} out
-                </div>
+                  <span class="font-medium text-gray-800 text-xs md:text-sm flex items-center gap-1">
+                    <span>{{ getCliRequestNumber(token.email) }} / {{ cliQuotaLimit }} {{ t('dash.acct.calls') }}</span>
+                    <span class="text-xs text-gray-400 transition-transform duration-200" :class="{ 'rotate-90': cliExpanded }">▸</span>
+                  </span>
+                </button>
+                <transition name="fade">
+                  <div v-if="cliExpanded" class="space-y-1 pt-1">
+                    <div class="text-xs text-gray-500 text-right">
+                      {{ t('dash.acct.cliSuccess') }}: {{ getAccountStats(token.email).cli.calls }}
+                    </div>
+                    <div class="h-2 bg-gray-200/60 rounded-full overflow-hidden">
+                      <div :style="{ width: getCliProgressPct(token.email) + '%' }"
+                           :class="getCliProgressColor(token.email)"
+                           class="h-full transition-all duration-300"></div>
+                    </div>
+                    <div class="text-xs text-gray-500 text-right">
+                      <span :title="String(getAccountStats(token.email).cli.input)">{{ formatCompact(getAccountStats(token.email).cli.input) }}</span>
+                      in /
+                      <span :title="String(getAccountStats(token.email).cli.output)">{{ formatCompact(getAccountStats(token.email).cli.output) }}</span>
+                      out
+                    </div>
+                  </div>
+                </transition>
               </div>
 
               <div class="pt-4 mt-auto border-t border-gray-200/50">
@@ -577,6 +594,27 @@ const getCliProgressColor = (email) => {
   if (pct >= 80) return 'bg-red-500'
   if (pct >= 50) return 'bg-amber-500'
   return 'bg-emerald-500'
+}
+
+// Compact number formatting (Qwen2API-j7x): 415575 → '415к', 1500 → '1.5к', 1500000 → '1.5M'.
+// <1000 — as is. Tooltip с полным значением применяется на уровне шаблона.
+const formatCompact = (n) => {
+  const num = Number(n) || 0
+  if (num < 1000) return String(num)
+  if (num < 1_000_000) {
+    const k = num / 1000
+    const formatted = k >= 100 ? Math.round(k) : (Math.round(k * 10) / 10)
+    return `${formatted}${t('dash.acct.unitK')}`
+  }
+  const m = num / 1_000_000
+  return `${Math.round(m * 10) / 10}${t('dash.acct.unitM')}`
+}
+
+// CLI accordion (Qwen2API-ao2): свёрнут по умолчанию, состояние общее для всех карточек в localStorage.
+const cliExpanded = ref(localStorage.getItem('cliExpanded') === '1')
+const toggleCliExpanded = () => {
+  cliExpanded.value = !cliExpanded.value
+  localStorage.setItem('cliExpanded', cliExpanded.value ? '1' : '0')
 }
 
 // Per-account status indicator (Qwen2API-3wg.3)

--- a/src/controllers/anthropic.js
+++ b/src/controllers/anthropic.js
@@ -1,6 +1,7 @@
 const { isJson, generateUUID } = require('../utils/tools.js');
 const { createUsageObject } = require('../utils/precise-tokenizer.js');
 const { sendChatRequest } = require('../utils/request.js');
+const accountManager = require('../utils/account.js');
 const { isChatType, isThinkingEnabled, parserModel, parserMessages } = require('../utils/chat-helpers.js');
 const {
   buildToolSystemPrompt,
@@ -9,6 +10,26 @@ const {
   createToolCallStreamParser
 } = require('../utils/tool-prompt.js');
 const { logger } = require('../utils/logger');
+
+/**
+ * 安全累计 chat stats（与 chat.js attributeChatUsage 共享语义）
+ * 静默吞掉异常——stats 累计失败不应中断响应
+ * 同 epic notes: tool-retry 全归属主账户（精度损失可接受）
+ * @param {Object} account - 主请求账户对象
+ * @param {number} promptTokens - 输入 tokens
+ * @param {number} completionTokens - 输出 tokens
+ */
+const attributeChatUsage = (account, promptTokens, completionTokens) => {
+  if (!account || !account.email) return;
+  try {
+    accountManager.accumulateStats(account.email, 'chat', {
+      input: Number(promptTokens) || 0,
+      output: Number(completionTokens) || 0
+    });
+  } catch (e) {
+    // 静默
+  }
+};
 
 /**
  * Anthropic stop_reason 枚举
@@ -501,6 +522,9 @@ const handleAnthropicStream = async (res, ctx, upstream) => {
     completionTokens = usage.completion_tokens || 0;
   }
 
+  // Daily stats 累计——一次性归属主账户（见模块顶部 attributeChatUsage 注释）
+  attributeChatUsage(ctx.currentAccount, promptTokens, completionTokens);
+
   writeAnthropicEvent(res, 'message_delta', {
     type: 'message_delta',
     delta: { stop_reason: stopReason, stop_sequence: null },
@@ -597,6 +621,9 @@ const handleAnthropicNonStream = async (res, ctx, upstream) => {
     });
   }
 
+  // Daily stats 累计——一次性归属主账户（同 stream 分支注释）
+  attributeChatUsage(ctx.currentAccount, promptTokens, completionTokens);
+
   res.set({ 'Content-Type': 'application/json' });
   res.json({
     id: message_id,
@@ -629,7 +656,7 @@ const handleAnthropicMessages = async (req, res) => {
     }
 
     const message_id = `msg_${generateUUID().replace(/-/g, '').slice(0, 24)}`;
-    const ctx = { message_id, model, hasTools, toolChoice, requestBody: body };
+    const ctx = { message_id, model, hasTools, toolChoice, requestBody: body, currentAccount: upstreamResp.currentAccount };
 
     if (req.body?.stream) {
       await handleAnthropicStream(res, ctx, upstreamResp.response);

--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -80,6 +80,23 @@ const buildRequiredRetryHint = (toolChoice) => {
  * @param {boolean} [options.has_tools] - 是否启用工具调用解析
  * @param {string|Object} [options.tool_choice] - OpenAI tool_choice 控制项
  */
+/**
+ * 安全累计 stats——任何异常都吞掉，不影响响应给客户端
+ * @param {Object} account - 当前账户对象（含 email）
+ * @param {Object} usage - { prompt_tokens, completion_tokens }
+ */
+const attributeChatUsage = (account, usage) => {
+    if (!account || !account.email || !usage) return
+    try {
+        accountManager.accumulateStats(account.email, 'chat', {
+            input: Number(usage.prompt_tokens) || 0,
+            output: Number(usage.completion_tokens) || 0
+        })
+    } catch (e) {
+        // 静默——stats 累计失败不应中断响应
+    }
+}
+
 const handleStreamResponse = async (res, response, enable_thinking, enable_web_search, requestBody = null, options = {}) => {
     try {
         const message_id = generateUUID()
@@ -369,6 +386,11 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
         totalTokens.completion_tokens = Math.max(0, totalTokens.completion_tokens || 0)
         totalTokens.total_tokens = totalTokens.prompt_tokens + totalTokens.completion_tokens
 
+        // Daily stats 累计——一次性归属到主请求账户
+        // 注：tool_choice=required retry 走的可能是另一个账户，但 retry 路径罕见，
+        // 全归属主账户是可接受的精度损失（PR #3wg.1 epic notes 已记）
+        attributeChatUsage(options.currentAccount, totalTokens)
+
         const finishReason = (toolParser && toolParser.hasEmittedAnyCall()) ? 'tool_calls' : 'stop'
         res.write(`data: ${JSON.stringify({
             "id": `chatcmpl-${message_id}`,
@@ -608,6 +630,9 @@ const handleNonStreamResponse = async (res, response, enable_thinking, enable_we
         totalTokens.completion_tokens = Math.max(0, totalTokens.completion_tokens || 0)
         totalTokens.total_tokens = totalTokens.prompt_tokens + totalTokens.completion_tokens
 
+        // Daily stats 累计——一次性归属到主请求账户（同 stream 分支注释）
+        attributeChatUsage(options.currentAccount, totalTokens)
+
         const assistantMessage = { role: 'assistant', content: assistantContent || null }
         if (toolCalls.length > 0) {
             assistantMessage.tool_calls = toolCalls
@@ -662,10 +687,10 @@ const handleChatCompletion = async (req, res) => {
 
         if (stream) {
             setResponseHeaders(res, true)
-            await handleStreamResponse(res, response_data.response, enable_thinking, enable_web_search, req.body, { has_tools: req.has_tools, tool_choice: req.tool_choice })
+            await handleStreamResponse(res, response_data.response, enable_thinking, enable_web_search, req.body, { has_tools: req.has_tools, tool_choice: req.tool_choice, currentAccount: response_data.currentAccount })
         } else {
             setResponseHeaders(res, false)
-            await handleNonStreamResponse(res, response_data.response, enable_thinking, enable_web_search, model, req.body, { has_tools: req.has_tools, tool_choice: req.tool_choice })
+            await handleNonStreamResponse(res, response_data.response, enable_thinking, enable_web_search, model, req.body, { has_tools: req.has_tools, tool_choice: req.tool_choice, currentAccount: response_data.currentAccount })
         }
 
     } catch (error) {

--- a/src/controllers/cli.chat.js
+++ b/src/controllers/cli.chat.js
@@ -1,6 +1,25 @@
 const axios = require('axios')
 const { logger } = require('../utils/logger')
+const accountManager = require('../utils/account')
 const { getProxyAgent, getCliBaseUrl, applyProxyToAxiosConfig } = require('../utils/proxy-helper')
+
+/**
+ * 静默累计 CLI daily stats——异常不影响响应
+ * @param {string} email - 账户邮箱
+ * @param {Object} usage - upstream usage { prompt_tokens, completion_tokens }
+ */
+const attributeCliUsage = (email, usage) => {
+    if (!email) return
+    try {
+        accountManager.accumulateStats(email, 'cli', {
+            calls: 1,
+            input: Number(usage?.prompt_tokens) || 0,
+            output: Number(usage?.completion_tokens) || 0
+        })
+    } catch (e) {
+        // 静默
+    }
+}
 
 const MODEL_REDIRECT = {
     'qwen3.5-plus': 'coder-model',
@@ -333,6 +352,8 @@ const handleCliChatCompletion = async (req, res) => {
                 requestBody: body,
                 details: errorDetails
             })
+            // HTTP 4xx/5xx——仅刷新 warn 指示, 不影响 cooldown（账户本身有效, 是上游主动拒绝）
+            accountManager.recordAccountError(req.account.email, response.status)
             return res.status(response.status).json({
                 error: {
                     message: `api_error`,
@@ -345,19 +366,43 @@ const handleCliChatCompletion = async (req, res) => {
 
         // 处理流式响应
         if (isStream) {
-            // 逐行转发，确保始终输出标准 SSE 片段
+            // 缓冲 SSE 解析——usage 帧可能跨 TCP 块（仅 split('\n\n') 会丢失），
+            // 沿用 chat.js/anthropic.js 的 buffer + while indexOf('\n\n') 模式
+            let sseBuffer = ''
+            let cliUsage = null
+
             response.data.on('data', (chunk) => {
                 const text = chunk.toString('utf8')
+                // 透传客户端: 逐行回写，保持原有行为
                 const lines = text.split('\n')
                 for (const line of lines) {
                     if (!line || !line.startsWith('data:')) continue
                     res.write(`${line}\n\n`)
+                }
+
+                // 解析 usage 帧（带缓冲——帧可能被分块切开）
+                sseBuffer += text
+                let idx
+                while ((idx = sseBuffer.indexOf('\n\n')) !== -1) {
+                    const frame = sseBuffer.slice(0, idx)
+                    sseBuffer = sseBuffer.slice(idx + 2)
+                    if (!frame.startsWith('data:')) continue
+                    const payload = frame.slice(frame.indexOf(':') + 1).trim()
+                    if (!payload || payload === '[DONE]') continue
+                    try {
+                        const parsed = JSON.parse(payload)
+                        if (parsed?.usage) cliUsage = parsed.usage
+                    } catch (e) {
+                        // 部分/非法 JSON——继续累计
+                    }
                 }
             })
 
             // 处理流错误
             response.data.on('error', (streamError) => {
                 logger.error(`CLI请求使用账号[${req.account.email}]流式传输失败 - 当前请求数: ${req.account.cli_info.request_number}`, 'CLI', '❌')
+                // 传输错误——记 failure（影响 cooldown）
+                accountManager.recordAccountFailure(req.account.email, streamError?.code)
                 if (!res.headersSent) {
                     res.status(500).json({
                         error: {
@@ -372,18 +417,27 @@ const handleCliChatCompletion = async (req, res) => {
             // 处理流结束
             response.data.on('end', () => {
                 logger.success(`CLI请求使用账号[${req.account.email}]转发成功 (流式) - 当前请求数: ${req.account.cli_info.request_number}`, 'CLI')
+                attributeCliUsage(req.account.email, cliUsage)
                 res.end()
             })
         } else {
             // 处理JSON响应
+            const cliUsage = response.data?.usage
             res.json(formatCliJsonResponse(response.data, body.model))
             logger.success(`CLI请求使用账号[${req.account.email}]转发成功 (JSON) - 当前请求数: ${req.account.cli_info.request_number}`, 'CLI')
+            attributeCliUsage(req.account.email, cliUsage)
         }
     } catch (error) {
         logger.error(`CLI请求使用账号[${req.account.email}]处理异常 - 当前请求数: ${req.account.cli_info.request_number}`, 'CLI', '💥', {
             requestBody: body,
             ...(await buildCliAxiosErrorLog(error))
         })
+        // catch 路径——区分传输错误（cooldown）与 HTTP 错误（warn-only）
+        if (error?.response) {
+            accountManager.recordAccountError(req.account.email, error.response.status)
+        } else {
+            accountManager.recordAccountFailure(req.account.email, error?.code)
+        }
 
         // 如果是axios错误，提供更详细的错误信息
         if (error.response) {

--- a/src/routes/accounts.js
+++ b/src/routes/accounts.js
@@ -606,4 +606,74 @@ router.post('/forceRefreshAllAccounts', adminKeyVerify, async (req, res) => {
 })
 
 
+/**
+ * GET /accountStats
+ * 返回 dashboard 用 daily stats + per-account status
+ * Status priority: cooldown > warn > token_expiring > active
+ *
+ * @returns {{
+ *   accounts: Array<{
+ *     email: string,
+ *     stats: { chat: {input,output}, cli: {calls,input,output} },
+ *     cliRequestNumber: number,
+ *     status: { kind: string, cooldownEndsAt: number|null, lastErrorAt: number|null, lastErrorCode: string|number|null }
+ *   }>,
+ *   cliQuotaLimit: number
+ * }}
+ */
+router.get('/accountStats', adminKeyVerify, async (req, res) => {
+  try {
+    const now = Date.now()
+    // 15 分钟 warn 窗口——recordError 写 lastErrorAt 后, UI 显示 🟡 warn 一段时间
+    const WARN_WINDOW_MS = 15 * 60 * 1000
+    // 6 小时——与 tokenManager.isTokenExpiringSoon default 一致
+    const TOKEN_EXPIRING_MS = 6 * 60 * 60 * 1000
+    // CLI 每日配额（与 routes/cli.chat.js:22 同步，dashboard 进度条用）
+    const CLI_QUOTA_LIMIT = 2000
+
+    const rotatorStats = accountManager.accountRotator.getStats()
+    const usageStats = rotatorStats.usageStats || {}
+
+    const accounts = accountManager.getAllAccountKeys().map(account => {
+      const email = account.email
+      const rotatorRecord = usageStats[email] || {}
+      const cooldownEndsAt = rotatorRecord.cooldownEndsAt || null
+      const lastErrorAt = rotatorRecord.lastErrorAt || null
+      const lastErrorCode = rotatorRecord.lastErrorCode || null
+
+      // 优先级：cooldown > warn > token_expiring > active
+      let kind = 'active'
+      if (cooldownEndsAt && now < cooldownEndsAt) {
+        kind = 'cooldown'
+      } else if (lastErrorAt && (now - lastErrorAt) < WARN_WINDOW_MS) {
+        kind = 'warn'
+      } else if (account.expires && (account.expires * 1000 - now) < TOKEN_EXPIRING_MS) {
+        // account.expires 是 UNIX seconds（JWT exp 直接保存）——*1000 得到 ms
+        // 直接对比 timestamp, 不调用 isTokenExpiringSoon(token)（后者接受 token 字符串而非 expires）
+        kind = 'token_expiring'
+      }
+
+      return {
+        email,
+        stats: account.stats || { chat: { input: 0, output: 0 }, cli: { calls: 0, input: 0, output: 0 } },
+        cliRequestNumber: account.cli_info?.request_number || 0,
+        status: {
+          kind,
+          cooldownEndsAt,
+          lastErrorAt,
+          lastErrorCode
+        }
+      }
+    })
+
+    res.json({
+      accounts,
+      cliQuotaLimit: CLI_QUOTA_LIMIT
+    })
+  } catch (error) {
+    logger.error('获取账户 stats 失败', 'ACCOUNT', '', error)
+    res.status(500).json({ error: error.message })
+  }
+})
+
 module.exports = router

--- a/src/utils/account-rotator.js
+++ b/src/utils/account-rotator.js
@@ -9,7 +9,10 @@ class AccountRotator {
     this.accounts = []
     this.currentIndex = 0
     this.lastUsedTimes = new Map() // 记录每个账户的最后使用时间
-    this.failureCounts = new Map() // 记录每个账户的失败次数
+    this.failureCounts = new Map() // 记录每个账户的失败次数（仅传输层失败累积，触发 cooldown）
+    this.lastErrorAt = new Map() // 最近一次错误的时间戳（用于 UI warn 指示，含 HTTP 4xx/5xx）
+    this.lastErrorCode = new Map() // 最近一次错误码（HTTP status 或 transport err.code）
+    this.cooldownStartedAt = new Map() // 进入 cooldown 的起始时间戳（failureCounts 达阈值时刻）
     this.maxFailures = 3 // 最大失败次数
     this.cooldownPeriod = 5 * 60 * 1000 // 5分钟冷却期
   }
@@ -95,24 +98,50 @@ class AccountRotator {
   }
 
   /**
-   * 记录账户使用失败
+   * 记录账户传输层失败（影响 cooldown）
+   * 仅在传输层错误（timeout/ECONNRESET 等）调用——HTTP 4xx/5xx 走 recordError
    * @param {string} email - 邮箱地址
+   * @param {string|number} [code] - 错误码（err.code 或 HTTP status），用于 UI warn
    */
-  recordFailure(email) {
+  recordFailure(email, code) {
     const currentFailures = this.failureCounts.get(email) || 0
-    this.failureCounts.set(email, currentFailures + 1)
-    
-    if (currentFailures + 1 >= this.maxFailures) {
+    const nextFailures = currentFailures + 1
+    this.failureCounts.set(email, nextFailures)
+
+    // 同时填充 warn 指示状态（recordFailure 是 recordError 的超集）
+    this.lastErrorAt.set(email, Date.now())
+    if (code !== undefined && code !== null) {
+      this.lastErrorCode.set(email, code)
+    }
+
+    // 达到阈值的瞬间标记 cooldown 起点（独立于 lastUsedTimes，CLI-only 失败也正确）
+    if (nextFailures >= this.maxFailures && !this.cooldownStartedAt.has(email)) {
+      this.cooldownStartedAt.set(email, Date.now())
       logger.warn(`账户 ${email} 失败次数达到上限，将进入冷却期`, 'ACCOUNT')
     }
   }
 
   /**
-   * 重置账户失败计数
+   * 记录账户错误（仅用于 UI warn 指示，不影响 cooldown）
+   * HTTP 4xx/5xx 走这里——上游主动拒绝，账户本身有效，不应进入 cooldown
+   * @param {string} email - 邮箱地址
+   * @param {string|number} [code] - HTTP status 或错误码
+   */
+  recordError(email, code) {
+    this.lastErrorAt.set(email, Date.now())
+    if (code !== undefined && code !== null) {
+      this.lastErrorCode.set(email, code)
+    }
+  }
+
+  /**
+   * 重置账户失败计数（清除 cooldown）
+   * 注意：不清理 lastErrorAt/lastErrorCode——它们由 endpoint 的 15 分钟窗口管理
    * @param {string} email - 邮箱地址
    */
   resetFailures(email) {
     this.failureCounts.delete(email)
+    this.cooldownStartedAt.delete(email)
   }
 
   /**
@@ -127,10 +156,14 @@ class AccountRotator {
     const usageStats = {}
     this.accounts.forEach(account => {
       const email = account.email
+      const cooldownStart = this.cooldownStartedAt.get(email)
       usageStats[email] = {
         failures: this.failureCounts.get(email) || 0,
         lastUsed: this.lastUsedTimes.get(email) || null,
-        available: this._isAccountAvailable(account)
+        available: this._isAccountAvailable(account),
+        lastErrorAt: this.lastErrorAt.get(email) || null,
+        lastErrorCode: this.lastErrorCode.get(email) || null,
+        cooldownEndsAt: cooldownStart ? cooldownStart + this.cooldownPeriod : null
       }
     })
 
@@ -162,15 +195,16 @@ class AccountRotator {
       return false
     }
 
-    const failures = this.failureCounts.get(account.email) || 0
-    if (failures >= this.maxFailures) {
-      const lastUsed = this.lastUsedTimes.get(account.email)
-      if (lastUsed && Date.now() - lastUsed < this.cooldownPeriod) {
+    // 基于 cooldownStartedAt（显式标记）而非 lastUsedTimes——
+    // 后者对 CLI-only 失败不更新，导致 cooldown 计算不准
+    const cooldownStart = this.cooldownStartedAt.get(account.email)
+    if (cooldownStart) {
+      if (Date.now() - cooldownStart < this.cooldownPeriod) {
         return false // 仍在冷却期
-      } else {
-        // 冷却期结束，重置失败计数
-        this.failureCounts.delete(account.email)
       }
+      // 冷却期结束，清理 cooldown 标记与失败计数（lastError* 不动，由 endpoint 管理 warn 窗口）
+      this.cooldownStartedAt.delete(account.email)
+      this.failureCounts.delete(account.email)
     }
 
     return true
@@ -237,18 +271,19 @@ class AccountRotator {
    */
   _cleanupRecords() {
     const currentEmails = new Set(this.accounts.map(acc => acc.email))
-    
-    // 清理失败计数记录
-    for (const email of this.failureCounts.keys()) {
-      if (!currentEmails.has(email)) {
-        this.failureCounts.delete(email)
-      }
-    }
-    
-    // 清理使用时间记录
-    for (const email of this.lastUsedTimes.keys()) {
-      if (!currentEmails.has(email)) {
-        this.lastUsedTimes.delete(email)
+
+    const maps = [
+      this.failureCounts,
+      this.lastUsedTimes,
+      this.lastErrorAt,
+      this.lastErrorCode,
+      this.cooldownStartedAt
+    ]
+    for (const map of maps) {
+      for (const email of map.keys()) {
+        if (!currentEmails.has(email)) {
+          map.delete(email)
+        }
       }
     }
   }
@@ -260,6 +295,9 @@ class AccountRotator {
     this.currentIndex = 0
     this.lastUsedTimes.clear()
     this.failureCounts.clear()
+    this.lastErrorAt.clear()
+    this.lastErrorCode.clear()
+    this.cooldownStartedAt.clear()
   }
 }
 

--- a/src/utils/account.js
+++ b/src/utils/account.js
@@ -3,6 +3,40 @@ const DataPersistence = require('./data-persistence')
 const TokenManager = require('./token-manager')
 const AccountRotator = require('./account-rotator')
 const { logger } = require('./logger')
+
+/**
+ * 默认 daily stats 结构。返回新对象，调用方安全修改
+ * @returns {Object} default stats
+ */
+const createDefaultStats = () => ({
+    chat: { input: 0, output: 0 },
+    cli: { calls: 0, input: 0, output: 0 }
+})
+
+/**
+ * 保证账户具备 stats 字段（兼容老 data.json/Redis 数据）
+ * @param {Object} account - 账户对象
+ */
+const ensureStats = (account) => {
+    if (!account) return
+    if (!account.stats || typeof account.stats !== 'object') {
+        account.stats = createDefaultStats()
+        return
+    }
+    if (!account.stats.chat || typeof account.stats.chat !== 'object') {
+        account.stats.chat = { input: 0, output: 0 }
+    } else {
+        account.stats.chat.input = Number(account.stats.chat.input) || 0
+        account.stats.chat.output = Number(account.stats.chat.output) || 0
+    }
+    if (!account.stats.cli || typeof account.stats.cli !== 'object') {
+        account.stats.cli = { calls: 0, input: 0, output: 0 }
+    } else {
+        account.stats.cli.calls = Number(account.stats.cli.calls) || 0
+        account.stats.cli.input = Number(account.stats.cli.input) || 0
+        account.stats.cli.output = Number(account.stats.cli.output) || 0
+    }
+}
 /**
  * 账户管理器
  * 统一管理账户、令牌、模型等功能
@@ -61,6 +95,9 @@ class Account {
     async loadAccountTokens() {
         try {
             this.accountTokens = await this.dataPersistence.loadAccounts()
+
+            // 兼容历史数据：旧 data.json/Redis 没有 stats 字段
+            this.accountTokens.forEach(ensureStats)
 
             // 如果是环境变量模式，需要进行登录获取令牌
             if (config.dataSaveMode === 'none' && this.accountTokens.length > 0) {
@@ -164,7 +201,7 @@ class Account {
      * @private
      */
     _setupDailyResetTimer() {
-        logger.info('设置CLI请求次数每日重置定时器', 'CLI')
+        logger.info('设置每日 00:00 重置定时器（CLI 请求次数 + daily stats）', 'CLI')
 
         // 计算到下一天00:00:00的毫秒数
         const now = new Date()
@@ -175,26 +212,53 @@ class Account {
 
         // 首次执行使用setTimeout
         this.cliRequestNumberInterval = setTimeout(() => {
-            // 重置所有CLI账户的请求次数
-            this._resetCliRequestNumbers()
+            this._resetDailyCounters()
 
             // 设置每24小时执行一次的定时器
             this.cliDailyResetInterval = setInterval(() => {
-                this._resetCliRequestNumbers()
+                this._resetDailyCounters()
             }, 24 * 60 * 60 * 1000)
         }, timeDiff)
     }
 
     /**
-     * 重置CLI请求次数
+     * 每日 00:00 重置：CLI 请求计数 + chat/cli daily stats
+     * 重置后立即 persist——否则 PM2 重启会从磁盘恢复昨日数据，让 reset 失去意义
      * @private
      */
-    _resetCliRequestNumbers() {
+    async _resetDailyCounters() {
+        // CLI 请求计数（旧逻辑）
         const cliAccounts = this.accountTokens.filter(account => account.cli_info)
         cliAccounts.forEach(account => {
             account.cli_info.request_number = 0
         })
-        logger.info(`已重置 ${cliAccounts.length} 个CLI账户的请求次数`, 'CLI')
+
+        // 新增：chat/cli daily stats
+        this.accountTokens.forEach(account => {
+            ensureStats(account)
+            account.stats.chat.input = 0
+            account.stats.chat.output = 0
+            account.stats.cli.calls = 0
+            account.stats.cli.input = 0
+            account.stats.cli.output = 0
+        })
+
+        logger.info(`已重置 ${cliAccounts.length} 个CLI账户的请求次数 + ${this.accountTokens.length} 个账户的 daily stats`, 'CLI')
+
+        // 立即 persist 以挺过 PM2 重启
+        try {
+            await this.dataPersistence.saveAllAccounts(this.accountTokens)
+        } catch (error) {
+            logger.error('每日重置后 persist 失败', 'ACCOUNT', '', error)
+        }
+    }
+
+    /**
+     * 重置CLI请求次数（向后兼容别名）
+     * @private
+     */
+    _resetCliRequestNumbers() {
+        return this._resetDailyCounters()
     }
 
     /**
@@ -505,11 +569,64 @@ class Account {
     }
 
     /**
-     * 记录账户使用失败
+     * 记录账户传输层失败（影响 cooldown）
+     * 仅在 timeout/ECONNRESET 等传输层错误调用——HTTP 4xx/5xx 走 recordAccountError
      * @param {string} email - 邮箱地址
+     * @param {string|number} [code] - 错误码（err.code 或 HTTP status）
      */
-    recordAccountFailure(email) {
-        this.accountRotator.recordFailure(email)
+    recordAccountFailure(email, code) {
+        this.accountRotator.recordFailure(email, code)
+    }
+
+    /**
+     * 记录账户错误（仅用于 UI warn 指示，不影响 cooldown）
+     * HTTP 4xx/5xx 走这里——上游主动拒绝，账户本身有效
+     * @param {string} email - 邮箱地址
+     * @param {string|number} [code] - HTTP status 或错误码
+     */
+    recordAccountError(email, code) {
+        this.accountRotator.recordError(email, code)
+    }
+
+    /**
+     * 累计 daily stats（per-account）
+     * 调用方：chat.js / anthropic.js / cli.chat.js 在成功消费完上游 usage 后
+     * 注意：PM2_INSTANCES>1 时各 worker 各持一份 in-memory 副本（已记于 epic notes）
+     * @param {string} email - 邮箱地址
+     * @param {'chat'|'cli'} kind - 统计类别
+     * @param {Object} delta - 增量
+     * @param {number} [delta.input] - 输入 tokens
+     * @param {number} [delta.output] - 输出 tokens
+     * @param {number} [delta.calls] - 调用次数（仅 cli 使用）
+     */
+    accumulateStats(email, kind, delta) {
+        if (!email || !delta) return
+        const account = this.accountTokens.find(acc => acc.email === email)
+        if (!account) return
+
+        ensureStats(account)
+
+        const input = Number(delta.input) || 0
+        const output = Number(delta.output) || 0
+        const calls = Number(delta.calls) || 0
+
+        if (kind === 'chat') {
+            account.stats.chat.input += input
+            account.stats.chat.output += output
+        } else if (kind === 'cli') {
+            account.stats.cli.calls += calls
+            account.stats.cli.input += input
+            account.stats.cli.output += output
+        } else {
+            return
+        }
+
+        // 异步 debounced persist——失败不影响调用方
+        try {
+            this.dataPersistence.saveAccountStats(email, account.stats)
+        } catch (error) {
+            logger.error(`accumulateStats persist 调度失败 (${email})`, 'STATS', '', error)
+        }
     }
 
     /**
@@ -554,7 +671,8 @@ class Account {
                 password,
                 token,
                 expires: decoded.exp,
-                proxy: (typeof proxy === 'string' && proxy.trim()) ? proxy.trim() : null
+                proxy: (typeof proxy === 'string' && proxy.trim()) ? proxy.trim() : null,
+                stats: createDefaultStats()
             }
 
             // 添加到内存
@@ -604,7 +722,8 @@ class Account {
                 password,
                 token,
                 expires,
-                proxy: (typeof proxy === 'string' && proxy.trim()) ? proxy.trim() : null
+                proxy: (typeof proxy === 'string' && proxy.trim()) ? proxy.trim() : null,
+                stats: createDefaultStats()
             }
 
             // 添加到内存

--- a/src/utils/account.js
+++ b/src/utils/account.js
@@ -110,12 +110,18 @@ class Account {
             // 更新账户轮询器
             this.accountRotator.setAccounts(this.accountTokens)
 
-            // 初始化 CLI 账户,随机初始化一个账号
+            // 初始化 CLI 账户（后台执行，不阻塞 chat-flow init）
+            // CLI poll 在 upstream 504 时可挂 5 分钟（cli.manager.js pollForToken: 60 次 × 5 秒），
+            // 而 chat-flow（/v1/chat/completions, /v1/messages）不需要 cli_info，无需等待。
+            // routes/cli.chat.js:22 已正确过滤无 cli_info 的账户，所以 /cli/* 在 CLI init 未完成时
+            // 自然回退到「无可用账户」状态。
             if (this.accountTokens.length > 0) {
                 const randomIndex = Math.floor(Math.random() * this.accountTokens.length)
                 const randomAccount = this.accountTokens[randomIndex]
-                logger.info(`初始化 CLI 账户, 随机初始化账号: ${randomAccount.email}`, 'ACCOUNT')
-                await this._initializeCliAccount(randomAccount)
+                logger.info(`后台初始化 CLI 账户, 随机初始化账号: ${randomAccount.email}`, 'ACCOUNT')
+                this._initializeCliAccount(randomAccount).catch(err => {
+                    logger.error(`CLI 账户后台初始化失败: ${randomAccount.email}`, 'ACCOUNT', '', err)
+                })
             }
 
             // 设置cli定时器 每天00:00:00刷新请求次数

--- a/src/utils/data-persistence.js
+++ b/src/utils/data-persistence.js
@@ -8,9 +8,15 @@ const { logger } = require('./logger')
  * 数据持久化管理器
  * 统一处理账户数据的存储和读取
  */
+// Debounce 窗口（per-email）写入 stats——避免每次 token 累计都触发文件 I/O
+const STATS_PERSIST_DEBOUNCE_MS = 5000
+
 class DataPersistence {
   constructor() {
     this.dataFilePath = path.join(__dirname, '../../data/data.json')
+    // 每个 email 的待持久化 stats 与定时器（debounce）
+    this._statsPersistTimers = new Map()
+    this._statsPendingPayload = new Map()
   }
 
   /**
@@ -209,33 +215,36 @@ class DataPersistence {
   }
 
   /**
-   * 保存到文件
+   * 保存到文件（MERGE 语义）
+   * partial save（仅 token、proxy、stats）不应覆盖未传字段——保留 existing 值
    * @private
    */
   async _saveToFile(email, accountData) {
     await this._ensureDataFileExists()
-    
+
     const fileContent = await fs.readFile(this.dataFilePath, 'utf-8')
     const data = JSON.parse(fileContent)
-    
+
     if (!data.accounts) {
       data.accounts = []
     }
 
-    // 查找现有账户或添加新账户
     const existingIndex = data.accounts.findIndex(account => account.email === email)
-    const updatedAccount = {
-      email,
-      password: accountData.password,
-      token: accountData.token,
-      expires: accountData.expires,
-      proxy: accountData.proxy ?? null
-    }
+    const existing = existingIndex !== -1 ? data.accounts[existingIndex] : {}
+
+    // 仅写入显式传入的字段；未传字段保留 existing 值。stats 同理——
+    // 避免 token refresh / proxy update 的 partial save 把累计 stats 清零
+    const merged = { ...existing, email }
+    if (accountData.password !== undefined) merged.password = accountData.password
+    if (accountData.token !== undefined) merged.token = accountData.token
+    if (accountData.expires !== undefined) merged.expires = accountData.expires
+    if (accountData.proxy !== undefined) merged.proxy = accountData.proxy ?? null
+    if (accountData.stats !== undefined) merged.stats = accountData.stats
 
     if (existingIndex !== -1) {
-      data.accounts[existingIndex] = updatedAccount
+      data.accounts[existingIndex] = merged
     } else {
-      data.accounts.push(updatedAccount)
+      data.accounts.push(merged)
     }
 
     await fs.writeFile(this.dataFilePath, JSON.stringify(data, null, 2), 'utf-8')
@@ -270,10 +279,48 @@ class DataPersistence {
       password: account.password,
       token: account.token,
       expires: account.expires,
-      proxy: account.proxy ?? null
+      proxy: account.proxy ?? null,
+      stats: account.stats ?? undefined
     }))
 
     await fs.writeFile(this.dataFilePath, JSON.stringify(data, null, 2), 'utf-8')
+    return true
+  }
+
+  /**
+   * 调度 per-account daily stats 持久化（debounce 5 秒）
+   * 高频 accumulateStats 调用合并为单次 I/O——重复调用替换上一个 timer
+   * dataSaveMode='none' 时不写盘，返回 false
+   * @param {string} email - 邮箱
+   * @param {Object} stats - 完整 stats 对象 { chat: {input,output}, cli: {calls,input,output} }
+   * @returns {boolean} 是否调度成功
+   */
+  saveAccountStats(email, stats) {
+    if (config.dataSaveMode === 'none') {
+      return false
+    }
+    if (!email || !stats) {
+      return false
+    }
+
+    // 替换 pending payload 与 timer
+    this._statsPendingPayload.set(email, stats)
+    const prev = this._statsPersistTimers.get(email)
+    if (prev) clearTimeout(prev)
+
+    const timer = setTimeout(async () => {
+      this._statsPersistTimers.delete(email)
+      const payload = this._statsPendingPayload.get(email)
+      this._statsPendingPayload.delete(email)
+      if (!payload) return
+      try {
+        await this.saveAccount(email, { stats: payload })
+      } catch (error) {
+        logger.error(`stats 持久化失败 (${email})`, 'STATS', '', error)
+      }
+    }, STATS_PERSIST_DEBOUNCE_MS)
+
+    this._statsPersistTimers.set(email, timer)
     return true
   }
 

--- a/src/utils/redis.js
+++ b/src/utils/redis.js
@@ -384,12 +384,23 @@ const getAllAccounts = async () => {
         logger.error(`账户 ${keys[index]} 数据为空`, 'REDIS')
         return null
       }
+      // stats 以 JSON 字符串存储于 HSET——malformed/missing 返回 undefined，由上层 ensureStats 补默认
+      let stats
+      if (accountData.stats) {
+        try {
+          stats = JSON.parse(accountData.stats)
+        } catch (parseError) {
+          logger.warn(`账户 ${keys[index]} stats JSON 解析失败，使用默认值: ${parseError.message}`, 'REDIS')
+          stats = undefined
+        }
+      }
       return {
         email: keys[index].replace('user:', ''),
         password: accountData.password || '',
         token: accountData.token || '',
         expires: accountData.expires || '',
-        proxy: accountData.proxy || null
+        proxy: accountData.proxy || null,
+        stats
       }
     }).filter(Boolean) // 过滤掉null值
 
@@ -411,13 +422,23 @@ const setAccount = async (key, value) => {
   try {
     const client = await ensureConnection()
 
-    const { password, token, expires, proxy } = value
-    await client.hset(`user:${key}`, {
-      password: password || '',
-      token: token || '',
-      expires: expires || '',
-      proxy: proxy || ''
-    })
+    const { password, token, expires, proxy, stats } = value
+
+    // 仅写入显式传入的字段——HSET 不影响其他字段，保留 MERGE 语义
+    // 这样 partial save（token refresh / proxy update）不会清零 daily stats
+    const payload = {}
+    if (password !== undefined) payload.password = password || ''
+    if (token !== undefined) payload.token = token || ''
+    if (expires !== undefined) payload.expires = expires || ''
+    if (proxy !== undefined) payload.proxy = proxy || ''
+    if (stats !== undefined) payload.stats = JSON.stringify(stats)
+
+    if (Object.keys(payload).length === 0) {
+      logger.warn(`账户 ${key} setAccount 收到空 payload，跳过写入`, 'REDIS')
+      return true
+    }
+
+    await client.hset(`user:${key}`, payload)
 
     logger.success(`账户 ${key} 设置成功`, 'REDIS')
     return true

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -94,14 +94,19 @@ const sendChatRequest = async (body) => {
             }
             const response = await axios.post(url, payload, requestConfig)
             if (response.status === 200) {
+                // 返回 currentAccount——调用方在消费完 stream 后据此累计 stats
+                // 注意：当前实现单次尝试都用同一个 currentAccount（不轮换），
+                // 如果未来 retry 切换账号，需要在切换处更新 currentAccount 引用
                 return {
                     currentToken,
+                    currentAccount,
                     status: true,
                     response: response.data
                 }
             }
-            // 非 200 但是没抛 — 退出цикла, обрабатываем как неуспех ниже
+            // 非 200 但是没抛——退出循环, 走下面错误分类
             lastError = new Error(`Unexpected status ${response.status}`)
+            lastError.response = { status: response.status }
             break
         } catch (error) {
             lastError = error
@@ -121,10 +126,10 @@ const sendChatRequest = async (body) => {
     }
 
     // 所有尝试失败 — 分类错误
-    if (lastError) {
+    if (lastError && currentAccount?.email) {
         const hadHttpResponse = !!lastError.response
-        if (!hadHttpResponse && isRetryableNetworkError(lastError) && currentAccount?.email) {
-            // 传输层失败耗尽重试 — 给账号记一次失败 (cooldown 由 account-rotator 处理)
+        if (!hadHttpResponse && isRetryableNetworkError(lastError)) {
+            // 传输层失败耗尽重试——记 failure，累计可触发 cooldown（PR #112 语义）
             logger.error(
                 `聊天请求传输失败 (已尝试 ${totalAttempts} 次): ${lastError.message}`,
                 'REQUEST'
@@ -134,11 +139,15 @@ const sendChatRequest = async (body) => {
                 'ACCOUNT',
                 '⏳'
             )
-            accountManager.recordAccountFailure(currentAccount.email)
+            accountManager.recordAccountFailure(currentAccount.email, lastError.code)
         } else {
-            // 收到 HTTP 响应 (上游问题, 不是账号问题) — 不影响 cooldown
+            // HTTP 4xx/5xx (上游主动拒绝, 账户有效) — 仅刷新 warn 指示, 不影响 cooldown
+            const status = lastError.response?.status
             logger.error('发送聊天请求失败', 'REQUEST', '', lastError.message)
+            accountManager.recordAccountError(currentAccount.email, status)
         }
+    } else if (lastError) {
+        logger.error('发送聊天请求失败', 'REQUEST', '', lastError.message)
     }
 
     return {


### PR DESCRIPTION
Closes #100

## 概述

此 PR 添加完整的每账户每日统计功能，包括 backend 累计、状态跟踪端点、
dashboard UI（统计块 + 状态指示 + 倒计时 + 紧凑数字格式 + CLI 折叠面板），
以及一个独立的 CLI init bugfix。

## 包含的 commits

1. **`feat(stats)`** — backend per-account daily stats + 状态跟踪端点
2. **`feat(dashboard)`** — 卡片上的统计块（Chat/CLI tokens）+ 按钮单行布局
3. **`feat(dashboard)`** — 状态指示器（emoji + cooldown 倒计时 + 灰化卡片）
4. **`feat(dashboard)`** — 紧凑数字格式（415к/k 替代 415575）+ CLI 折叠面板
5. **`fix(account)`** — CLI init 不阻塞主 chat-flow init（upstream 504 时启动从 5 分钟降至 1 秒）

## Backend 变更

### 新功能

1. **每账户统计累计**：`account.js` 添加 `accumulateStats(email, kind, delta)`。
   chat-flow（`/v1/chat/completions`, `/v1/messages`）和 CLI-flow
   （`/cli/v1/chat/completions`）在每个上游响应完整消费后归属累计。
2. **状态跟踪端点** `GET /api/accountStats`：返回每个账户的 `stats`、
   `cliRequestNumber`、`status`（kind: `cooldown` / `warn` / `token_expiring` /
   `active`）。优先级 `cooldown > warn > token_expiring > active`。
3. **错误分类拆分**：account-rotator 拆分 `recordError`（仅记录
   `lastErrorAt`/`lastErrorCode`，用于 warn 指示）和 `recordFailure`
   （增加 failures counter + 触发 cooldown，用于传输错误）。
   保持 PR #112 的回退语义：HTTP 4xx/5xx 不进入 cooldown
   （上游决定，账户有效），传输错误（timeout/ECONNRESET）进入 cooldown。
4. **显式 `cooldownStartedAt`**：替换 lastUsedTimes-based cooldown 公式
   （对 CLI-only 失败不正确，因为 CLI 绕过 rotator 不更新 `lastUsedTimes`）。
5. **每日重置完整化**：`_resetCliRequestNumbers` → `_resetDailyCounters`，
   额外重置 `stats.chat` 和 `stats.cli`。重置后立即 persist，PM2 重启不丢失。
6. **CLI streaming usage 解析**：`cli.chat.js` 添加 buffered SSE parser
   （与 chat.js/anthropic.js 一致），正确解析跨 TCP-chunk 分割的 usage 帧。

### 持久化

- `data-persistence.saveAccount`：MERGE rule —— partial save（token refresh,
  proxy update）不覆盖 persisted stats。
- `redis.js`：stats 作为 `JSON.stringify` 在 HSET。
- 调度持久化 debounce 5s per-email，避免高频累计造成 I/O 风暴。
- `DATA_SAVE_MODE=none` 时不写盘，纯内存。

### CLI init bugfix

`account.js` 中 `loadAccountTokens()` 之前使用 `await this._initializeCliAccount(randomAccount)`
同步等待 CLI 初始化。当上游 504 时，CLI poll 会运行 60 次 × 5s = **5 分钟**，期间
`isInitialized=false`，所有 chat 请求都返回 `账户管理器尚未初始化完成`。
即使是基础 chat-flow（`/v1/chat/completions`, `/v1/messages`），不依赖 `cli_info`，
也被阻塞。

修复：将 `await` 改为 fire-and-forget + `.catch`。`isInitialized=true` 在加载基础
账户数据后立即设置（秒级）。CLI 初始化在后台继续。`routes/cli.chat.js:22` 已经
正确过滤无 `cli_info` 的账户，所以 `/cli/*` 在 CLI 初始化未完成时自然回退到
"无可用账户" 状态。

## Frontend 变更（基于 upstream 已有的 vue-i18n 基础设施）

### Dashboard 卡片新增

- **统计块**：每个账户卡片显示 `Chat (今日): X in / Y out` 和 `CLI (今日): N / 2000 次调用`，
  附带进度条（颜色根据使用率变化：emerald < 50% < amber < 80% < red）。
- **状态指示器**：右上角 emoji（🟢 active / 🟡 warn / 🔴 cooldown / 🪫 token_expiring），
  cooldown 时附加 mm:ss 倒计时；卡片灰化（opacity-60 grayscale）；tooltip 显示本地化描述。
- **倒计时刷新**：cooldown 到期后 watcher 自动重新拉取 `/api/accountStats`，
  per-account suppression Map 防止重复调用。
- **紧凑数字格式**：415575 → "415к/k"，1500 → "1.5к/k"，1500000 → "1.5M"。
  `<1000` 保持原样。tooltip 显示完整数字。
- **CLI 折叠面板**：CLI 块默认折叠（虚线下划线标题 + ▸ 箭头）。点击展开显示
  进度条 + token 详情。状态保存在 localStorage（所有卡片共享）。
- **紧凑按钮行**：3 个管理按钮（修改代理 / 刷新令牌 / 删除账号）改为单行 flex 布局，
  释放垂直空间给统计块。

### i18n

- `dash.acct.*` 命名空间：`chatToday`, `cliToday`, `calls`, `cliSuccess`, `unitK`, `unitM`
- `dash.acct.status.*`：`active`, `warn`, `warnNoCode`, `cooldown`, `tokenExpiring`, `unitSec`, `unitMin`
- 完整翻译到 ru 和 zh

## Dashboard 效果

![Dashboard stats](https://raw.githubusercontent.com/weselow/Qwen2API/production/docs/images/dashboard-stats.png)

## 兼容性

- 旧 `data.json` / Redis 无 `stats` 字段：load 时 `ensureStats` 初始化为零。
- API 契约 `/v1/chat/completions`, `/v1/messages`, `/cli/v1/chat/completions`
  完全不变。
- 已知限制：`PM2_INSTANCES > 1` 时 stats per-worker（在代码注释中标注）。
  完整修复需要 Redis-backed stats，超出此 PR 范围。

## Test plan

### Backend
- [ ] `/v1/chat/completions` 单次请求 → `/api/accountStats` 对应账户增加准确数值
- [ ] `/v1/messages` (Anthropic) 同上
- [ ] `/cli/v1/chat/completions` 增加 `cli.calls` + `cli.input/output` 和 `cliRequestNumber`
- [ ] 重启服务后 stats 保留（DATA_SAVE_MODE=file 或 redis）
- [ ] `DATA_SAVE_MODE=none` 时不写盘
- [ ] Daily reset @ 00:00 清零并 persist
- [ ] HTTP 4xx/5xx 仅触发 warn 指示，不进入 cooldown
- [ ] 传输错误进入 cooldown（保持 PR #112 行为）
- [ ] 上游 504 启动时间 < 10s（之前需要 5 分钟）

### Frontend
- [ ] 每张卡片显示 Chat/CLI 统计块和状态 emoji
- [ ] 415575 → "415к/k"，hover tooltip 显示 "415575"
- [ ] 点击 CLI 标题展开/折叠，F5 后状态保留
- [ ] cooldown 时卡片灰化 + 倒计时实时更新
- [ ] cooldown 到期后无需 F5，自动刷新统计
- [ ] 切换 ru ↔ zh 所有字符串本地化

<details>
<summary>English version</summary>

Closes #100

## Overview

This PR adds the complete per-account daily stats feature: backend accumulation,
status tracking endpoint, dashboard UI (stats block + status indicator +
countdown + compact number formatting + CLI accordion), plus a standalone CLI
init bugfix.

## Commits

1. **`feat(stats)`** — backend per-account daily stats + status endpoint
2. **`feat(dashboard)`** — stats block on card (Chat/CLI tokens) + compact buttons
3. **`feat(dashboard)`** — status indicator (emoji + cooldown countdown + grey card)
4. **`feat(dashboard)`** — compact number formatting (415k vs 415575) + CLI accordion
5. **`fix(account)`** — CLI init does not block main chat-flow init (startup drops from 5 min to 1 sec under upstream 504)

## Backend

### New features

1. **Per-account stats accumulation**: `account.js` adds
   `accumulateStats(email, kind, delta)`. chat-flow
   (`/v1/chat/completions`, `/v1/messages`) and CLI-flow
   (`/cli/v1/chat/completions`) attribute after full upstream-response consumption.
2. **Status tracking endpoint** `GET /api/accountStats`: returns per-account
   `stats`, `cliRequestNumber`, `status` (kind: `cooldown` / `warn` /
   `token_expiring` / `active`). Priority: `cooldown > warn > token_expiring > active`.
3. **Error classification split**: account-rotator splits `recordError`
   (records `lastErrorAt`/`lastErrorCode` only — for warn indicator) vs
   `recordFailure` (increments failures counter + triggers cooldown — for
   transport errors). Preserves PR #112 resilience semantics.
4. **Explicit `cooldownStartedAt`**: replaces lastUsedTimes-based cooldown
   formula (incorrect for CLI-only failures).
5. **Daily reset completeness**: `_resetCliRequestNumbers` →
   `_resetDailyCounters`, additionally resets `stats.chat` and `stats.cli`.
   Persists immediately after reset.
6. **CLI streaming usage parsing**: `cli.chat.js` adds buffered SSE parser.

### Persistence

- `data-persistence.saveAccount`: MERGE rule — partial saves don't overwrite stats.
- `redis.js`: stats as `JSON.stringify` in HSET.
- 5s debounce per-email persist scheduling.
- `DATA_SAVE_MODE=none`: in-memory only.

### CLI init bugfix

`account.js` `loadAccountTokens()` previously used `await this._initializeCliAccount()`
synchronously. Under upstream 504, CLI poll runs 60 × 5s = **5 minutes**, during
which `isInitialized=false` and all chat requests return "account manager not
initialized". Even basic chat-flow (`/v1/chat/completions`, `/v1/messages`),
which doesn't depend on `cli_info`, was blocked.

Fix: change `await` to fire-and-forget with `.catch`. `isInitialized=true` is set
within seconds after loading base account data. CLI init continues in background.
`routes/cli.chat.js:22` already correctly filters accounts without `cli_info`, so
`/cli/*` naturally falls back to "no available accounts" when CLI init isn't done.

## Frontend (uses upstream's existing vue-i18n setup)

### Dashboard card additions

- **Stats block**: each card shows `Chat (today): X in / Y out` and
  `CLI (today): N / 2000 calls` with progress bar (color shifts: emerald < 50%
  < amber < 80% < red).
- **Status indicator**: top-right emoji (🟢 / 🟡 / 🔴 / 🪫), cooldown shows
  mm:ss countdown; card greys out (opacity-60 grayscale); tooltip with
  localized description.
- **Auto-refetch on cooldown expiry**: watcher triggers `/api/accountStats`
  refetch with per-account suppression Map to avoid duplicates.
- **Compact number formatting**: 415575 → "415k", 1500 → "1.5k",
  1500000 → "1.5M". `<1000` as-is. Tooltip shows full value.
- **CLI accordion**: CLI block collapsed by default (dotted-underline header +
  ▸ chevron). Click expands progress bar + token details. State in localStorage
  (shared across cards).
- **Compact button row**: 3 management buttons (edit proxy / refresh token /
  delete account) reformatted to single flex row to free vertical space.

### i18n

- `dash.acct.*` namespace: `chatToday`, `cliToday`, `calls`, `cliSuccess`,
  `unitK`, `unitM`
- `dash.acct.status.*`: `active`, `warn`, `warnNoCode`, `cooldown`,
  `tokenExpiring`, `unitSec`, `unitMin`
- Full ru and zh translations

## Compatibility

- Legacy `data.json` / Redis without `stats`: `ensureStats` zero-inits on load.
- API contracts unchanged.
- Known limitation: under `PM2_INSTANCES > 1` stats are per-worker.

## Test plan

### Backend
- [ ] `/v1/chat/completions` single request → `/api/accountStats` shows accurate increment
- [ ] `/v1/messages` (Anthropic) same
- [ ] `/cli/v1/chat/completions` increments `cli.calls` + `cli.input/output` and `cliRequestNumber`
- [ ] Service restart preserves stats (DATA_SAVE_MODE=file or redis)
- [ ] `DATA_SAVE_MODE=none` does not persist to disk
- [ ] Daily reset @ 00:00 zeros and persists
- [ ] HTTP 4xx/5xx only triggers warn, no cooldown
- [ ] Transport errors trigger cooldown (preserves PR #112)
- [ ] Startup under upstream 504 takes < 10s (was 5 min)

### Frontend
- [ ] Every card displays Chat/CLI stats block and status emoji
- [ ] 415575 → "415k", hover tooltip shows "415575"
- [ ] Click CLI title toggles expand/collapse, F5 preserves state
- [ ] Cooldown greys card + countdown ticks every second
- [ ] After cooldown expiry stats refresh without F5
- [ ] ru ↔ zh switch localizes all strings

</details>

