### PR TITLE
feat(stats): 90-day daily token history + GET /statsHistory

### DIFF
--- a/public/package.json
+++ b/public/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "axios": "^1.8.4",
+    "chart.js": "^4.4.0",
     "vue": "^3.4.29",
+    "vue-chartjs": "^5.3.0",
     "vue-i18n": "^11.1.3",
     "vue-router": "^4.5.0"
   },

--- a/public/src/components/StatsAccountCard.vue
+++ b/public/src/components/StatsAccountCard.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="bg-white/40 backdrop-blur-md border border-white/30 rounded-2xl shadow-md p-4">
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2 mb-3">
+      <div class="font-semibold text-gray-800 break-all">{{ account.email }}</div>
+      <div class="flex flex-wrap gap-2 text-xs">
+        <span class="px-2 py-1 rounded-lg bg-indigo-50 border border-indigo-100 text-indigo-700" :title="String(totals.chatInput)">
+          {{ t('stats.totals.chatInput') }}: {{ formatCompact(totals.chatInput, fmtUnits) }}
+        </span>
+        <span class="px-2 py-1 rounded-lg bg-emerald-50 border border-emerald-100 text-emerald-700" :title="String(totals.chatOutput)">
+          {{ t('stats.totals.chatOutput') }}: {{ formatCompact(totals.chatOutput, fmtUnits) }}
+        </span>
+        <span class="px-2 py-1 rounded-lg bg-indigo-50 border border-indigo-100 text-indigo-700" :title="String(totals.cliInput)">
+          {{ t('stats.totals.cliInput') }}: {{ formatCompact(totals.cliInput, fmtUnits) }}
+        </span>
+        <span class="px-2 py-1 rounded-lg bg-emerald-50 border border-emerald-100 text-emerald-700" :title="String(totals.cliOutput)">
+          {{ t('stats.totals.cliOutput') }}: {{ formatCompact(totals.cliOutput, fmtUnits) }}
+        </span>
+        <span class="px-2 py-1 rounded-lg bg-amber-50 border border-amber-100 text-amber-700" :title="String(totals.cliCalls)">
+          {{ t('stats.totals.cliCalls') }}: {{ formatCompact(totals.cliCalls, fmtUnits) }}
+        </span>
+      </div>
+    </div>
+
+    <div v-if="hasData" class="grid grid-cols-1 md:grid-cols-2 gap-2">
+      <div class="bg-white/60 rounded-lg p-2">
+        <div class="text-xs text-gray-600 mb-1">{{ t('stats.chart.input') }}</div>
+        <SvgSparkline :values="inputs" color="#6366f1" />
+      </div>
+      <div class="bg-white/60 rounded-lg p-2">
+        <div class="text-xs text-gray-600 mb-1">{{ t('stats.chart.output') }}</div>
+        <SvgSparkline :values="outputs" color="#10b981" />
+      </div>
+    </div>
+    <div v-else class="text-center text-gray-400 text-sm py-3">{{ t('stats.account.noData') }}</div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import SvgSparkline from './SvgSparkline.vue'
+import { formatCompact } from '../utils/format.js'
+
+const props = defineProps({
+  account: { type: Object, required: true }, // { email, history }
+  range: { type: Array, required: true }     // ['YYYY-MM-DD', ...] in chronological order
+})
+
+const { t } = useI18n()
+
+const fmtUnits = computed(() => ({
+  unitK: t('dash.acct.unitK'),
+  unitM: t('dash.acct.unitM')
+}))
+
+const days = computed(() => {
+  const history = props.account.history || {}
+  return props.range.map(date => {
+    const entry = history[date] || { chat: {}, cli: {} }
+    const chat = entry.chat || {}
+    const cli = entry.cli || {}
+    return {
+      date,
+      chatInput: Number(chat.input) || 0,
+      chatOutput: Number(chat.output) || 0,
+      cliInput: Number(cli.input) || 0,
+      cliOutput: Number(cli.output) || 0,
+      cliCalls: Number(cli.calls) || 0
+    }
+  })
+})
+
+const totals = computed(() => days.value.reduce((acc, d) => ({
+  chatInput: acc.chatInput + d.chatInput,
+  chatOutput: acc.chatOutput + d.chatOutput,
+  cliInput: acc.cliInput + d.cliInput,
+  cliOutput: acc.cliOutput + d.cliOutput,
+  cliCalls: acc.cliCalls + d.cliCalls
+}), { chatInput: 0, chatOutput: 0, cliInput: 0, cliOutput: 0, cliCalls: 0 }))
+
+const inputs = computed(() => days.value.map(d => d.chatInput + d.cliInput))
+const outputs = computed(() => days.value.map(d => d.chatOutput + d.cliOutput))
+
+const hasData = computed(() => inputs.value.some(v => v > 0) || outputs.value.some(v => v > 0))
+</script>

--- a/public/src/components/StatsBarChart.vue
+++ b/public/src/components/StatsBarChart.vue
@@ -1,0 +1,59 @@
+<template>
+  <Bar :data="chartData" :options="chartOptions" />
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { Bar } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend
+} from 'chart.js'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend)
+
+const props = defineProps({
+  labels: { type: Array, required: true },
+  inputs: { type: Array, required: true },
+  outputs: { type: Array, required: true },
+  inputLabel: { type: String, default: 'Input' },
+  outputLabel: { type: String, default: 'Output' }
+})
+
+const chartData = computed(() => ({
+  labels: props.labels,
+  datasets: [
+    {
+      label: props.inputLabel,
+      data: props.inputs,
+      backgroundColor: 'rgba(99, 102, 241, 0.7)',
+      borderColor: 'rgba(99, 102, 241, 1)',
+      borderWidth: 1
+    },
+    {
+      label: props.outputLabel,
+      data: props.outputs,
+      backgroundColor: 'rgba(16, 185, 129, 0.7)',
+      borderColor: 'rgba(16, 185, 129, 1)',
+      borderWidth: 1
+    }
+  ]
+}))
+
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { position: 'top' },
+    tooltip: { mode: 'index', intersect: false }
+  },
+  scales: {
+    x: { stacked: false, ticks: { maxRotation: 0, autoSkip: true, maxTicksLimit: 12 } },
+    y: { stacked: false, beginAtZero: true }
+  }
+}
+</script>

--- a/public/src/components/StatsTotals.vue
+++ b/public/src/components/StatsTotals.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="bg-white/30 backdrop-blur-md border border-white/30 rounded-2xl shadow-xl p-6 mb-6">
+    <h2 class="text-2xl font-bold mb-4">{{ t('stats.totals.label') }}</h2>
+
+    <div class="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
+      <div class="bg-white/60 rounded-xl p-3 border border-indigo-100">
+        <div class="text-xs text-gray-600">{{ t('stats.totals.chatInput') }}</div>
+        <div class="text-2xl font-bold text-indigo-700" :title="String(totals.chatInput)">
+          {{ formatCompact(totals.chatInput, fmtUnits) }}
+        </div>
+      </div>
+      <div class="bg-white/60 rounded-xl p-3 border border-emerald-100">
+        <div class="text-xs text-gray-600">{{ t('stats.totals.chatOutput') }}</div>
+        <div class="text-2xl font-bold text-emerald-700" :title="String(totals.chatOutput)">
+          {{ formatCompact(totals.chatOutput, fmtUnits) }}
+        </div>
+      </div>
+      <div class="bg-white/60 rounded-xl p-3 border border-indigo-100">
+        <div class="text-xs text-gray-600">{{ t('stats.totals.cliInput') }}</div>
+        <div class="text-2xl font-bold text-indigo-700" :title="String(totals.cliInput)">
+          {{ formatCompact(totals.cliInput, fmtUnits) }}
+        </div>
+      </div>
+      <div class="bg-white/60 rounded-xl p-3 border border-emerald-100">
+        <div class="text-xs text-gray-600">{{ t('stats.totals.cliOutput') }}</div>
+        <div class="text-2xl font-bold text-emerald-700" :title="String(totals.cliOutput)">
+          {{ formatCompact(totals.cliOutput, fmtUnits) }}
+        </div>
+      </div>
+      <div class="bg-white/60 rounded-xl p-3 border border-amber-100">
+        <div class="text-xs text-gray-600">{{ t('stats.totals.cliCalls') }}</div>
+        <div class="text-2xl font-bold text-amber-700" :title="String(totals.cliCalls)">
+          {{ formatCompact(totals.cliCalls, fmtUnits) }}
+        </div>
+      </div>
+    </div>
+
+    <div v-if="hasData" class="h-64 md:h-72">
+      <StatsBarChart
+        :labels="labels"
+        :inputs="inputs"
+        :outputs="outputs"
+        :input-label="t('stats.chart.input')"
+        :output-label="t('stats.chart.output')"
+      />
+    </div>
+    <div v-else class="text-center text-gray-500 py-8">{{ t('stats.account.noData') }}</div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import StatsBarChart from './StatsBarChart.vue'
+import { formatCompact } from '../utils/format.js'
+
+const props = defineProps({
+  totals: { type: Object, required: true },
+  daily: { type: Array, required: true } // [{ date, chatInput, chatOutput, cliInput, cliOutput, cliCalls }]
+})
+
+const { t } = useI18n()
+
+const fmtUnits = computed(() => ({
+  unitK: t('dash.acct.unitK'),
+  unitM: t('dash.acct.unitM')
+}))
+
+const labels = computed(() => props.daily.map(d => d.date))
+const inputs = computed(() => props.daily.map(d => (d.chatInput || 0) + (d.cliInput || 0)))
+const outputs = computed(() => props.daily.map(d => (d.chatOutput || 0) + (d.cliOutput || 0)))
+
+const hasData = computed(() => inputs.value.some(v => v > 0) || outputs.value.some(v => v > 0))
+</script>

--- a/public/src/components/SvgSparkline.vue
+++ b/public/src/components/SvgSparkline.vue
@@ -1,0 +1,47 @@
+<template>
+  <svg
+    :viewBox="`0 0 ${width} ${height}`"
+    preserveAspectRatio="none"
+    class="block w-full"
+    :style="{ height: height + 'px' }"
+    aria-hidden="true"
+  >
+    <polyline
+      v-if="points"
+      :points="points"
+      fill="none"
+      :stroke="color"
+      stroke-width="1.5"
+      stroke-linejoin="round"
+      stroke-linecap="round"
+    />
+  </svg>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  values: { type: Array, required: true },
+  color: { type: String, default: '#6366f1' },
+  height: { type: Number, default: 30 }
+})
+
+const width = 100
+
+// Polyline built from normalized values. Skip when all zero or fewer than two points.
+const points = computed(() => {
+  const vals = Array.isArray(props.values) ? props.values : []
+  if (vals.length < 2) return ''
+  const max = Math.max(...vals)
+  if (max <= 0) return ''
+  const step = width / (vals.length - 1)
+  return vals
+    .map((v, i) => {
+      const x = i * step
+      const y = props.height - (Number(v) || 0) / max * props.height
+      return `${x.toFixed(2)},${y.toFixed(2)}`
+    })
+    .join(' ')
+})
+</script>

--- a/public/src/locales/ru.json
+++ b/public/src/locales/ru.json
@@ -13,6 +13,7 @@
     "forceRefreshing": "Принудительное обновление...",
     "forceRefresh": "Принудительное обновление",
     "export": "Экспорт аккаунтов",
+    "statistics": "Статистика",
     "settings": "Настройки",
     "perPage": "На странице:",
     "totalItems": "Всего: {n}",
@@ -173,5 +174,33 @@
     "label": "🌐 Язык / Language",
     "ru": "Русский",
     "zh": "中文"
+  },
+  "stats": {
+    "title": "Статистика",
+    "loading": "Загрузка...",
+    "loadFailed": "Не удалось загрузить статистику: ",
+    "backToDashboard": "К аккаунтам",
+    "filter": {
+      "label": "Период",
+      "currentMonth": "Текущий месяц",
+      "prevMonth": "Прошлый месяц",
+      "last90": "Последние 90 дней"
+    },
+    "totals": {
+      "label": "Итог по всем аккаунтам",
+      "chatInput": "Chat вход",
+      "chatOutput": "Chat выход",
+      "cliInput": "CLI вход",
+      "cliOutput": "CLI выход",
+      "cliCalls": "CLI запросов"
+    },
+    "account": {
+      "label": "По аккаунтам",
+      "noData": "Нет данных за период"
+    },
+    "chart": {
+      "input": "Вход",
+      "output": "Выход"
+    }
   }
 }

--- a/public/src/locales/zh.json
+++ b/public/src/locales/zh.json
@@ -13,6 +13,7 @@
     "forceRefreshing": "强制刷新中...",
     "forceRefresh": "强制刷新",
     "export": "导出账号",
+    "statistics": "统计",
     "settings": "系统设置",
     "perPage": "每页显示:",
     "totalItems": "共 {n} 项",
@@ -173,5 +174,33 @@
     "label": "🌐 语言 / Language",
     "ru": "Русский",
     "zh": "中文"
+  },
+  "stats": {
+    "title": "统计",
+    "loading": "加载中...",
+    "loadFailed": "加载统计失败：",
+    "backToDashboard": "返回账号管理",
+    "filter": {
+      "label": "时间范围",
+      "currentMonth": "当月",
+      "prevMonth": "上月",
+      "last90": "最近 90 天"
+    },
+    "totals": {
+      "label": "全部账号汇总",
+      "chatInput": "Chat 输入",
+      "chatOutput": "Chat 输出",
+      "cliInput": "CLI 输入",
+      "cliOutput": "CLI 输出",
+      "cliCalls": "CLI 调用"
+    },
+    "account": {
+      "label": "按账号",
+      "noData": "该时间段无数据"
+    },
+    "chart": {
+      "input": "输入",
+      "output": "输出"
+    }
   }
 }

--- a/public/src/routes/index.js
+++ b/public/src/routes/index.js
@@ -16,6 +16,11 @@ const routes = [
     name: 'settings',
     path: '/settings',
     component: () => import('../views/settings.vue')
+  },
+  {
+    name: 'statistics',
+    path: '/statistics',
+    component: () => import('../views/statistics.vue')
   }
 ]
 
@@ -48,7 +53,7 @@ router.beforeEach(async (to, from, next) => {
           localStorage.setItem('isAdmin', isAdmin.toString())
 
           // 检查是否需要管理员权限
-          if ((to.path === '/' || to.path === '/settings') && !isAdmin) {
+          if ((to.path === '/' || to.path === '/settings' || to.path === '/statistics') && !isAdmin) {
             alert('您没有访问管理页面的权限')
             next({ path: '/auth' })
             return

--- a/public/src/utils/format.js
+++ b/public/src/utils/format.js
@@ -1,0 +1,16 @@
+// Compact number formatting: 415575 → '415k', 1500 → '1.5k', 1500000 → '1.5M'.
+// <1000 — no suffix. Utility stays vue-i18n-agnostic: units are passed in
+// explicitly so this remains pure and testable. Callers supply
+// t('dash.acct.unitK') / t('dash.acct.unitM').
+export function formatCompact(n, units = {}) {
+  const { unitK = 'k', unitM = 'M' } = units
+  const num = Number(n) || 0
+  if (num < 1000) return String(num)
+  if (num < 1_000_000) {
+    const k = num / 1000
+    const formatted = k >= 100 ? Math.round(k) : (Math.round(k * 10) / 10)
+    return `${formatted}${unitK}`
+  }
+  const m = num / 1_000_000
+  return `${Math.round(m * 10) / 10}${unitM}`
+}

--- a/public/src/views/dashboard.vue
+++ b/public/src/views/dashboard.vue
@@ -3,7 +3,9 @@
     <div class="container mx-auto">
       <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-6 px-4 space-y-4 md:space-y-0 pt-5">
         <h1 class="text-4xl font-bold">{{ t('dash.title') }} <span class="text-gray-500 text-sm">by 兜豆子</span></h1>
-        <div class="grid grid-cols-2 sm:flex sm:flex-row w-full md:w-auto gap-2 sm:gap-0 sm:space-x-2 lg:space-x-4">
+        <div class="flex flex-col md:flex-row md:items-center w-full md:w-auto gap-3">
+          <!-- 6 buttons in 2 rows on desktop (3+3), 2 columns on mobile -->
+          <div class="grid grid-cols-2 md:grid-cols-3 gap-2 md:gap-3 w-full md:w-auto">
           <button @click="showAddModal = true"
                   class="action-button font-bold border border-green-200 bg-green-50 text-green-900 px-4 py-2 rounded-xl shadow-sm hover:bg-green-100 hover:border-green-400 transition-all duration-300 transform hover:-translate-y-1 active:translate-y-0 text-center">
             {{ t('dash.addAccount') }}
@@ -46,11 +48,16 @@
                   class="action-button font-bold border border-yellow-200 bg-yellow-50 text-yellow-900 px-4 py-2 rounded-xl shadow-sm hover:bg-yellow-100 hover:border-yellow-400 transition-all duration-300 transform hover:-translate-y-1 active:translate-y-0 text-center">
             {{ t('dash.export') }}
           </button>
+          <router-link to="/statistics"
+                       class="action-button font-bold border border-indigo-200 bg-indigo-50 text-indigo-900 px-4 py-2 rounded-xl shadow-sm hover:bg-indigo-100 hover:border-indigo-400 transition-all duration-300 transform hover:-translate-y-1 active:translate-y-0 text-center">
+            {{ t('dash.statistics') }}
+          </router-link>
           <router-link to="/settings"
                        class="action-button font-bold border border-blue-200 bg-blue-50 text-blue-900 px-4 py-2 rounded-xl shadow-sm hover:bg-blue-100 hover:border-blue-400 transition-all duration-300 transform hover:-translate-y-1 active:translate-y-0 text-center">
             {{ t('dash.settings') }}
           </router-link>
-          <LangSwitcher class="col-span-2 sm:col-span-1 justify-self-center" />
+          </div>
+          <LangSwitcher class="self-center md:self-auto" />
         </div>
       </div>
 
@@ -524,6 +531,7 @@ import { ref, onMounted, onBeforeUnmount, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import axios from 'axios'
 import LangSwitcher from '../components/LangSwitcher.vue'
+import { formatCompact as _formatCompact } from '../utils/format.js'
 
 const { t } = useI18n()
 
@@ -597,18 +605,8 @@ const getCliProgressColor = (email) => {
 }
 
 // Compact number formatting (Qwen2API-j7x): 415575 → '415к', 1500 → '1.5к', 1500000 → '1.5M'.
-// <1000 — as is. Tooltip с полным значением применяется на уровне шаблона.
-const formatCompact = (n) => {
-  const num = Number(n) || 0
-  if (num < 1000) return String(num)
-  if (num < 1_000_000) {
-    const k = num / 1000
-    const formatted = k >= 100 ? Math.round(k) : (Math.round(k * 10) / 10)
-    return `${formatted}${t('dash.acct.unitK')}`
-  }
-  const m = num / 1_000_000
-  return `${Math.round(m * 10) / 10}${t('dash.acct.unitM')}`
-}
+// Implementation moved to ../utils/format.js (shared with /statistics).
+const formatCompact = (n) => _formatCompact(n, { unitK: t('dash.acct.unitK'), unitM: t('dash.acct.unitM') })
 
 // CLI accordion (Qwen2API-ao2): свёрнут по умолчанию, состояние общее для всех карточек в localStorage.
 const cliExpanded = ref(localStorage.getItem('cliExpanded') === '1')

--- a/public/src/views/statistics.vue
+++ b/public/src/views/statistics.vue
@@ -1,0 +1,176 @@
+<template>
+  <div class="dashboard-scroll w-100vw h-100vh p-4 overflow-y-auto">
+    <div class="container mx-auto">
+      <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-6 px-4 space-y-4 md:space-y-0 pt-5">
+        <div class="flex items-center gap-3">
+          <router-link
+            to="/"
+            class="action-button font-bold border border-gray-200 bg-white/60 text-gray-800 px-3 py-2 rounded-xl shadow-sm hover:bg-white/90 transition-all duration-300"
+          >
+            ← {{ t('stats.backToDashboard') }}
+          </router-link>
+          <h1 class="text-3xl md:text-4xl font-bold">{{ t('stats.title') }}</h1>
+        </div>
+        <LangSwitcher />
+      </div>
+
+      <div class="px-4 mb-6">
+        <div class="inline-flex flex-wrap gap-2 bg-white/50 backdrop-blur-sm border border-white/40 rounded-2xl p-2 shadow">
+          <button
+            v-for="opt in periodOptions"
+            :key="opt.value"
+            @click="period = opt.value"
+            :class="[
+              'px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200',
+              period === opt.value
+                ? 'bg-indigo-100 text-indigo-800 border border-indigo-300'
+                : 'bg-transparent text-gray-700 hover:bg-white/70 border border-transparent'
+            ]"
+          >
+            {{ opt.label }}
+          </button>
+        </div>
+      </div>
+
+      <div v-if="loading" class="text-center py-12 text-gray-500">
+        <svg class="animate-spin h-6 w-6 mx-auto mb-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="m4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+        {{ t('stats.loading') }}
+      </div>
+
+      <div v-else class="px-4">
+        <StatsTotals :totals="aggregateTotals" :daily="aggregateDaily" />
+
+        <div class="text-lg font-semibold mb-3">{{ t('stats.account.label') }}</div>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <StatsAccountCard
+            v-for="acc in accounts"
+            :key="acc.email"
+            :account="acc"
+            :range="dateRange"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import axios from 'axios'
+import LangSwitcher from '../components/LangSwitcher.vue'
+import StatsTotals from '../components/StatsTotals.vue'
+import StatsAccountCard from '../components/StatsAccountCard.vue'
+
+const { t } = useI18n()
+
+const loading = ref(true)
+const accounts = ref([])
+// Server-side date — anchor for every period range. Paired with the
+// _getYesterdayKey helper used by the archival routine; do not switch this
+// to new Date() in the browser — differing browser/container TZs would
+// shift month boundaries.
+const serverToday = ref(new Date().toISOString().slice(0, 10))
+
+const period = ref('currentMonth')
+const periodOptions = computed(() => [
+  { value: 'currentMonth', label: t('stats.filter.currentMonth') },
+  { value: 'prevMonth', label: t('stats.filter.prevMonth') },
+  { value: 'last90', label: t('stats.filter.last90') }
+])
+
+// Parse YYYY-MM-DD as a local date.
+function parseDateKey(key) {
+  const [y, m, d] = key.split('-').map(Number)
+  return new Date(y, m - 1, d)
+}
+function formatDateKey(date) {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+function daysInMonth(year, monthIndex0) {
+  return new Date(year, monthIndex0 + 1, 0).getDate()
+}
+
+// dateRange — array of YYYY-MM-DD keys in chronological order, anchored to serverToday.
+const dateRange = computed(() => {
+  const today = parseDateKey(serverToday.value)
+  const result = []
+  if (period.value === 'last90') {
+    for (let i = 89; i >= 0; i--) {
+      const d = new Date(today)
+      d.setDate(d.getDate() - i)
+      result.push(formatDateKey(d))
+    }
+  } else if (period.value === 'currentMonth') {
+    const year = today.getFullYear()
+    const m0 = today.getMonth()
+    const last = daysInMonth(year, m0)
+    for (let day = 1; day <= last; day++) {
+      result.push(formatDateKey(new Date(year, m0, day)))
+    }
+  } else if (period.value === 'prevMonth') {
+    const prev = new Date(today.getFullYear(), today.getMonth() - 1, 1)
+    const year = prev.getFullYear()
+    const m0 = prev.getMonth()
+    const last = daysInMonth(year, m0)
+    for (let day = 1; day <= last; day++) {
+      result.push(formatDateKey(new Date(year, m0, day)))
+    }
+  }
+  return result
+})
+
+// Daily aggregate across all accounts — feeds the summary bar chart.
+const aggregateDaily = computed(() => dateRange.value.map(date => {
+  let chatInput = 0, chatOutput = 0, cliInput = 0, cliOutput = 0, cliCalls = 0
+  for (const acc of accounts.value) {
+    const entry = (acc.history || {})[date]
+    if (!entry) continue
+    const chat = entry.chat || {}
+    const cli = entry.cli || {}
+    chatInput += Number(chat.input) || 0
+    chatOutput += Number(chat.output) || 0
+    cliInput += Number(cli.input) || 0
+    cliOutput += Number(cli.output) || 0
+    cliCalls += Number(cli.calls) || 0
+  }
+  return { date, chatInput, chatOutput, cliInput, cliOutput, cliCalls }
+}))
+
+const aggregateTotals = computed(() => aggregateDaily.value.reduce((acc, d) => ({
+  chatInput: acc.chatInput + d.chatInput,
+  chatOutput: acc.chatOutput + d.chatOutput,
+  cliInput: acc.cliInput + d.cliInput,
+  cliOutput: acc.cliOutput + d.cliOutput,
+  cliCalls: acc.cliCalls + d.cliCalls
+}), { chatInput: 0, chatOutput: 0, cliInput: 0, cliOutput: 0, cliCalls: 0 }))
+
+// Strictly validate `today` before using it to build dateRange — without this,
+// a malformed '2026-13-99' would slip through new Date(y, m-1, d) (JS would
+// roll the date over) and the UI would render the wrong window.
+const DATE_KEY_REGEX = /^\d{4}-\d{2}-\d{2}$/
+
+onMounted(async () => {
+  try {
+    const response = await axios.get('/api/statsHistory', {
+      headers: { Authorization: localStorage.getItem('apiKey') || '' }
+    })
+    const apiToday = response.data?.today
+    if (typeof apiToday === 'string' && DATE_KEY_REGEX.test(apiToday)) {
+      serverToday.value = apiToday
+    }
+    accounts.value = response.data?.accounts || []
+  } catch (error) {
+    console.error('Failed to load statsHistory', error)
+    alert(t('stats.loadFailed') + (error?.message || ''))
+  } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/src/routes/accounts.js
+++ b/src/routes/accounts.js
@@ -676,4 +676,105 @@ router.get('/accountStats', adminKeyVerify, async (req, res) => {
   }
 })
 
+/**
+ * GET /statsHistory
+ * 返回 dashboard /statistics 用 — 历史每日 token 消耗 (90 天 retention).
+ * 今日数据合并自 account.stats (live counter) 到 history[today]，
+ * 避免新部署后首日 UI 全空。
+ *
+ * Known edge-case: a ~5 s window at 00:00 between resetting stats=0 and
+ * writing statsHistory[yesterday] via saveAllAccounts — a brief "sag"
+ * once per day. Not patched (seconds, once per day).
+ *
+ * @returns {{
+ *   today: string,                            // YYYY-MM-DD in server TZ
+ *   accounts: Array<{
+ *     email: string,
+ *     history: Record<string, { chat: {input,output}, cli: {calls,input,output} }>
+ *   }>
+ * }}
+ */
+router.get('/statsHistory', adminKeyVerify, async (req, res) => {
+  try {
+    // today is the same helper used by the archival routine (paired with
+    // _getYesterdayKey). The frontend MUST build ranges (currentMonth /
+    // prevMonth / last90) off this value, not new Date() — otherwise
+    // differing browser/container TZs can shift month boundaries.
+    const today = accountManager.getTodayKey()
+
+    const accounts = accountManager.getAllAccountKeys().map(account => {
+      // Deep copy of history: the 5 s window at 00:00 has _resetDailyCounters
+      // mutating nested chat/cli entries; a shallow top-level copy does not
+      // protect against that. The deep copy avoids handing the client a
+      // half-reset snapshot.
+      const history = {}
+      const src = account.statsHistory || {}
+      for (const key of Object.keys(src)) {
+        const entry = src[key] || {}
+        const chat = entry.chat || {}
+        const cli = entry.cli || {}
+        history[key] = {
+          chat: { input: Number(chat.input) || 0, output: Number(chat.output) || 0 },
+          cli: {
+            calls: Number(cli.calls) || 0,
+            input: Number(cli.input) || 0,
+            output: Number(cli.output) || 0
+          }
+        }
+      }
+
+      // Today is the live counter from account.stats.
+      // Deep copy of chat/cli — otherwise a concurrent accumulateStats call
+      // may mutate the object already handed out.
+      const s = account.stats || { chat: { input: 0, output: 0 }, cli: { calls: 0, input: 0, output: 0 } }
+      history[today] = {
+        chat: { input: Number(s.chat?.input) || 0, output: Number(s.chat?.output) || 0 },
+        cli: {
+          calls: Number(s.cli?.calls) || 0,
+          input: Number(s.cli?.input) || 0,
+          output: Number(s.cli?.output) || 0
+        }
+      }
+
+      return { email: account.email, history }
+    })
+
+    res.json({ today, accounts })
+  } catch (error) {
+    logger.error('获取 statsHistory 失败', 'ACCOUNT', '', error)
+    res.status(500).json({ error: error.message })
+  }
+})
+
+/**
+ * POST /debug/archiveYesterday
+ * Debug-only: manual trigger for the archival/reset routine (used while
+ * smoke-testing the storage layer).
+ *
+ * Registered ONLY when ENABLE_STATS_DEBUG_ARCHIVE === 'true'.
+ * NODE_ENV is intentionally NOT used — this repo does not set it
+ * (src/start.js, ecosystem.config.js), so 'production' cannot be guaranteed.
+ *
+ * In any normal (including production) configuration the route is absent —
+ * POST returns 404. Caveat: GET on any unknown path falls into app.get('*')
+ * and returns the SPA with status 200, so always verify route absence with
+ * `-X POST`.
+ */
+if (process.env.ENABLE_STATS_DEBUG_ARCHIVE === 'true') {
+  router.post('/debug/archiveYesterday', adminKeyVerify, async (req, res) => {
+    try {
+      await accountManager.archiveYesterdayForTest()
+      res.json({ ok: true, archivedAt: new Date().toISOString() })
+    } catch (error) {
+      // The readiness guard inside archiveYesterdayForTest throws with this message.
+      if (error && error.message && error.message.includes('not initialized')) {
+        return res.status(503).json({ error: 'account manager not initialized, try again' })
+      }
+      logger.error('debug/archiveYesterday 失败', 'ACCOUNT', '', error)
+      res.status(500).json({ error: error.message })
+    }
+  })
+  logger.info('已启用 debug/archiveYesterday 端点 (ENABLE_STATS_DEBUG_ARCHIVE=true)', 'ACCOUNT')
+}
+
 module.exports = router

--- a/src/utils/account.js
+++ b/src/utils/account.js
@@ -14,29 +14,65 @@ const createDefaultStats = () => ({
 })
 
 /**
- * 保证账户具备 stats 字段（兼容老 data.json/Redis 数据）
+ * 保证账户具备 stats 和 statsHistory 字段（兼容老 data.json/Redis 数据）
  * @param {Object} account - 账户对象
  */
 const ensureStats = (account) => {
     if (!account) return
     if (!account.stats || typeof account.stats !== 'object') {
         account.stats = createDefaultStats()
-        return
-    }
-    if (!account.stats.chat || typeof account.stats.chat !== 'object') {
-        account.stats.chat = { input: 0, output: 0 }
     } else {
-        account.stats.chat.input = Number(account.stats.chat.input) || 0
-        account.stats.chat.output = Number(account.stats.chat.output) || 0
+        if (!account.stats.chat || typeof account.stats.chat !== 'object') {
+            account.stats.chat = { input: 0, output: 0 }
+        } else {
+            account.stats.chat.input = Number(account.stats.chat.input) || 0
+            account.stats.chat.output = Number(account.stats.chat.output) || 0
+        }
+        if (!account.stats.cli || typeof account.stats.cli !== 'object') {
+            account.stats.cli = { calls: 0, input: 0, output: 0 }
+        } else {
+            account.stats.cli.calls = Number(account.stats.cli.calls) || 0
+            account.stats.cli.input = Number(account.stats.cli.input) || 0
+            account.stats.cli.output = Number(account.stats.cli.output) || 0
+        }
     }
-    if (!account.stats.cli || typeof account.stats.cli !== 'object') {
-        account.stats.cli = { calls: 0, input: 0, output: 0 }
-    } else {
-        account.stats.cli.calls = Number(account.stats.cli.calls) || 0
-        account.stats.cli.input = Number(account.stats.cli.input) || 0
-        account.stats.cli.output = Number(account.stats.cli.output) || 0
+    // statsHistory: { 'YYYY-MM-DD': { chat:{input,output}, cli:{calls,input,output} } }
+    // Backward-compat: legacy records without the field — initialize to {}
+    if (!account.statsHistory || typeof account.statsHistory !== 'object') {
+        account.statsHistory = {}
     }
 }
+
+/**
+ * YYYY-MM-DD date key for (now + offsetDays) in Node process local TZ
+ * @param {number} offsetDays - day offset (negative = past)
+ * @returns {string}
+ */
+const _formatDateKey = (offsetDays) => {
+    const d = new Date()
+    d.setDate(d.getDate() + offsetDays)
+    const yyyy = d.getFullYear()
+    const mm = String(d.getMonth() + 1).padStart(2, '0')
+    const dd = String(d.getDate()).padStart(2, '0')
+    return `${yyyy}-${mm}-${dd}`
+}
+
+const _getTodayKey = () => _formatDateKey(0)
+const _getYesterdayKey = () => _formatDateKey(-1)
+const _dateKeyDaysAgo = (n) => _formatDateKey(-n)
+
+const _hasNonZeroStats = (stats) => {
+    if (!stats || typeof stats !== 'object') return false
+    const c = stats.chat || {}
+    const l = stats.cli || {}
+    return (Number(c.input) || 0) > 0
+        || (Number(c.output) || 0) > 0
+        || (Number(l.calls) || 0) > 0
+        || (Number(l.input) || 0) > 0
+        || (Number(l.output) || 0) > 0
+}
+
+const STATS_HISTORY_RETENTION_DAYS = 90
 /**
  * 账户管理器
  * 统一管理账户、令牌、模型等功能
@@ -59,8 +95,8 @@ class Account {
         this.cliRequestNumberInterval = null
         this.cliDailyResetInterval = null
 
-        // 初始化
-        this._initialize()
+        // Keep the init promise so debug methods can await readiness
+        this._initPromise = this._initialize()
     }
 
     /**
@@ -228,8 +264,18 @@ class Account {
     }
 
     /**
-     * 每日 00:00 重置：CLI 请求计数 + chat/cli daily stats
-     * 重置后立即 persist——否则 PM2 重启会从磁盘恢复昨日数据，让 reset 失去意义
+     * Daily 00:00 reset: CLI request counters + chat/cli daily stats.
+     * Before zeroing, snapshot yesterday into account.statsHistory and prune
+     * entries older than STATS_HISTORY_RETENTION_DAYS days, then a single
+     * saveAllAccounts batch (instead of 30 individual saves).
+     *
+     * Caveats:
+     * - PM2_INSTANCES > 1: each worker archives its own partial copy of stats;
+     *   the daily total would be under-reported proportionally to the worker
+     *   count. With instances=1 (ecosystem.config.js default) this is not
+     *   triggered.
+     * - DATA_SAVE_MODE=none: saveAllAccounts returns false and history is not
+     *   persisted. Set DATA_SAVE_MODE=file or redis to enable the feature.
      * @private
      */
     async _resetDailyCounters() {
@@ -239,9 +285,32 @@ class Account {
             account.cli_info.request_number = 0
         })
 
-        // 新增：chat/cli daily stats
+        const yesterday = _getYesterdayKey()
+        const cutoff = _dateKeyDaysAgo(STATS_HISTORY_RETENTION_DAYS)
+        let archivedCount = 0
+
+        // For every account (including inactive ones) prune old history;
+        // for accounts with any non-zero counters, snapshot yesterday.
         this.accountTokens.forEach(account => {
             ensureStats(account)
+
+            // Date-based pruning (string compare is valid for YYYY-MM-DD).
+            for (const key of Object.keys(account.statsHistory)) {
+                if (key < cutoff) {
+                    delete account.statsHistory[key]
+                }
+            }
+
+            // Snapshot only if there was at least one non-zero counter.
+            if (_hasNonZeroStats(account.stats)) {
+                account.statsHistory[yesterday] = {
+                    chat: { ...account.stats.chat },
+                    cli: { ...account.stats.cli }
+                }
+                archivedCount++
+            }
+
+            // Reset today.
             account.stats.chat.input = 0
             account.stats.chat.output = 0
             account.stats.cli.calls = 0
@@ -249,14 +318,45 @@ class Account {
             account.stats.cli.output = 0
         })
 
-        logger.info(`已重置 ${cliAccounts.length} 个CLI账户的请求次数 + ${this.accountTokens.length} 个账户的 daily stats`, 'CLI')
+        logger.info(
+            `已重置 ${cliAccounts.length} 个CLI账户请求次数 + ${this.accountTokens.length} 个账户 daily stats，归档 ${archivedCount} 条 statsHistory[${yesterday}]`,
+            'CLI'
+        )
 
-        // 立即 persist 以挺过 PM2 重启
+        // Single batch save. In file mode — one data.json rewrite; in redis
+        // mode — sequential HSETs (the saveAccountStats debounce is not used).
         try {
             await this.dataPersistence.saveAllAccounts(this.accountTokens)
         } catch (error) {
             logger.error('每日重置后 persist 失败', 'ACCOUNT', '', error)
         }
+    }
+
+    /**
+     * Public helper: today's YYYY-MM-DD key in Node process local TZ.
+     * Paired with the _getYesterdayKey used inside _resetDailyCounters.
+     * The /statsHistory route must use this rather than new Date() in the
+     * browser — otherwise differing browser/container TZs can shift month
+     * boundaries.
+     * @returns {string}
+     */
+    getTodayKey() {
+        return _getTodayKey()
+    }
+
+    /**
+     * Debug: manual trigger for archive/reset (used by the dev endpoint).
+     * The readiness guard prevents wiping data.accounts = [] before init finishes.
+     * @returns {Promise<void>}
+     */
+    async archiveYesterdayForTest() {
+        if (this._initPromise) {
+            await this._initPromise
+        }
+        if (!this.isInitialized || !Array.isArray(this.accountTokens) || this.accountTokens.length === 0) {
+            throw new Error('account manager not initialized — refusing to archive (would wipe data)')
+        }
+        return this._resetDailyCounters()
     }
 
     /**

--- a/src/utils/data-persistence.js
+++ b/src/utils/data-persistence.js
@@ -240,6 +240,7 @@ class DataPersistence {
     if (accountData.expires !== undefined) merged.expires = accountData.expires
     if (accountData.proxy !== undefined) merged.proxy = accountData.proxy ?? null
     if (accountData.stats !== undefined) merged.stats = accountData.stats
+    if (accountData.statsHistory !== undefined) merged.statsHistory = accountData.statsHistory
 
     if (existingIndex !== -1) {
       data.accounts[existingIndex] = merged
@@ -280,7 +281,8 @@ class DataPersistence {
       token: account.token,
       expires: account.expires,
       proxy: account.proxy ?? null,
-      stats: account.stats ?? undefined
+      stats: account.stats ?? undefined,
+      statsHistory: account.statsHistory ?? undefined
     }))
 
     await fs.writeFile(this.dataFilePath, JSON.stringify(data, null, 2), 'utf-8')

--- a/src/utils/data-persistence.js
+++ b/src/utils/data-persistence.js
@@ -71,7 +71,7 @@ class DataPersistence {
   /**
    * 加载运行时设置（chat retry config 等）
    * 在 'none' 模式下返回 {}, 因为没有可写存储
-   * @returns {Promise<Object>} 设置对象 (空对象表示无сохранённых значений)
+   * @returns {Promise<Object>} 设置对象 (空对象表示尚未存储任何值)
    */
   async loadSettings() {
     try {

--- a/src/utils/redis.js
+++ b/src/utils/redis.js
@@ -487,7 +487,7 @@ const SETTINGS_KEY = 'qwen2api:settings'
 
 /**
  * 获取运行时设置
- * @returns {Promise<Object>} 设置对象 (字段类型 — string, 调用方ответственен за parseInt)
+ * @returns {Promise<Object>} 设置对象 (字段类型为 string，调用方需自行 parseInt)
  */
 const getSettings = async () => {
   try {
@@ -501,7 +501,7 @@ const getSettings = async () => {
 }
 
 /**
- * 保存运行时设置（部分合并 через hset）
+ * 保存运行时设置（通过 hset 部分合并）
  * @param {Object} partial - 字段
  * @returns {Promise<boolean>} 设置是否成功
  */

--- a/src/utils/redis.js
+++ b/src/utils/redis.js
@@ -394,13 +394,24 @@ const getAllAccounts = async () => {
           stats = undefined
         }
       }
+      // statsHistory is stored as a JSON string in HSET; malformed/missing → undefined, ensureStats fills {} upstream
+      let statsHistory
+      if (accountData.statsHistory) {
+        try {
+          statsHistory = JSON.parse(accountData.statsHistory)
+        } catch (parseError) {
+          logger.warn(`账户 ${keys[index]} statsHistory JSON 解析失败，使用默认值: ${parseError.message}`, 'REDIS')
+          statsHistory = undefined
+        }
+      }
       return {
         email: keys[index].replace('user:', ''),
         password: accountData.password || '',
         token: accountData.token || '',
         expires: accountData.expires || '',
         proxy: accountData.proxy || null,
-        stats
+        stats,
+        statsHistory
       }
     }).filter(Boolean) // 过滤掉null值
 
@@ -422,7 +433,7 @@ const setAccount = async (key, value) => {
   try {
     const client = await ensureConnection()
 
-    const { password, token, expires, proxy, stats } = value
+    const { password, token, expires, proxy, stats, statsHistory } = value
 
     // 仅写入显式传入的字段——HSET 不影响其他字段，保留 MERGE 语义
     // 这样 partial save（token refresh / proxy update）不会清零 daily stats
@@ -432,6 +443,7 @@ const setAccount = async (key, value) => {
     if (expires !== undefined) payload.expires = expires || ''
     if (proxy !== undefined) payload.proxy = proxy || ''
     if (stats !== undefined) payload.stats = JSON.stringify(stats)
+    if (statsHistory !== undefined) payload.statsHistory = JSON.stringify(statsHistory)
 
     if (Object.keys(payload).length === 0) {
       logger.warn(`账户 ${key} setAccount 收到空 payload，跳过写入`, 'REDIS')


### PR DESCRIPTION
我不喜欢半途而废，所以决定把每个账号的 daily stats 完整收尾。

接续 PR #114（per-account daily stats）的工作。现状：chat/cli 计数在每天 00:00 被 `_resetDailyCounters` 清零，昨天的数据就此丢失，无法回看历史趋势。

本 PR 一次性补齐 storage、API 与 UI：

- 每账户 90 天 rolling retention 历史（`account.statsHistory`，键为 YYYY-MM-DD）
- 一个 admin-key 保护的查询端点 `GET /api/statsHistory`
- 一个可选的、env-flag 保护的 debug 端点（用于首次部署的烟雾测试）
- 一个新的 `/statistics` 页面，复用现有的 vue-i18n / LangSwitcher / glassmorphism 样式

### 改动概要

**存储 + 归档**（d435426）
- `ensureStats()` 向后兼容：旧记录自动补 `statsHistory = {}`
- `_resetDailyCounters()` 重写：先按日期剪枝（YYYY-MM-DD 字符串比较合法），再快照昨日（仅当至少一个计数器非零；空白日子不写），再清零 today
- 收尾单次 `saveAllAccounts` 批量写盘（file 模式一次 data.json 重写，redis 模式逐个 HSET）
- `data-persistence.js` 与 `redis.js` 沿用现有 `stats` 字段的 MERGE 语义，`statsHistory` 同样处理
- 公开 helper `getTodayKey()` 与内部 `_getYesterdayKey` 配对，调用方必须用它构造时间区间，否则浏览器/容器 TZ 错位会跨月

**只读 API + 调试端点**（8161b7a）
- `GET /api/statsHistory`：返回 `{today, accounts:[{email, history}]}`，今天数据从 live `account.stats` 合并到 `history[today]`，避免首日空白
- 深拷贝 `history` 与 `chat`/`cli`：保护 00:00 大约 5 秒窗口里 `_resetDailyCounters` 的并发 mutation
- `POST /api/debug/archiveYesterday`：仅当 `ENABLE_STATS_DEBUG_ARCHIVE === 'true'` 注册。故意不用 `NODE_ENV` — 仓库不设置它（`start.js` / `ecosystem.config.js`），无法保证 `production`。普通配置下 POST 返回 404（注意：GET 任何未知路径都会落入 `app.get('*')` 返回 SPA + 200，所以必须用 `-X POST` 验证路由不存在）

**前端**（0ec09b3）
- 新增 lazy 路由 `/statistics`，auth-guard 同步扩展
- 页面组件 `views/statistics.vue`：周期过滤（当月 / 上月 / 最近 90 天）+ 全量汇总卡 + 每账号卡。所有时间区间都从 `response.data.today` 推导，并用严格 `^\d{4}-\d{2}-\d{2}$` 验证，从不调用 `new Date()`，因此浏览器/容器 TZ 不会跨月错位
- 混合渲染策略：汇总用一个 Chart.js bar-chart（含 legend/tooltip），账号卡用纯 SVG `<polyline>` sparkline（约 40 行），30+ 账号也能瞬时渲染
- 新组件：`StatsTotals.vue`、`StatsAccountCard.vue`、`StatsBarChart.vue`（vue-chartjs Bar 的薄封装，自带 Chart.js 模块注册）、`SvgSparkline.vue`（零依赖）
- 工具函数：从 `dashboard.vue` 抽出的 `formatCompact(n, {unitK, unitM})` 移到 `public/src/utils/format.js`，units 显式传入以保持工具与 vue-i18n 解耦，调用方传 `t('dash.acct.unitK')` / `t('dash.acct.unitM')`
- i18n：`locales/{ru,zh}.json` 新增 `stats.*` namespace + `dash.statistics`，两个语言键完全对齐
- Dashboard 头部：新加 "统计" 按钮路由到 `/statistics`，同时把 6 个动作按钮重排为桌面端 3+3 网格（移动端 2 列），语言切换器从网格里抽出来。之前中等宽度下 "强制刷新" 会折行
- 依赖：`chart.js@^4`、`vue-chartjs@^5`。整套 Chart.js 只在进入 `/statistics` 时通过 lazy 路由按需加载，主 dashboard bundle 不受影响（statistics chunk 57 KB gzip，主 index 80 KB gzip）

### 已知限制

- `PM2_INSTANCES > 1`：每个 worker 各持一份 in-memory stats 副本，归档结果会偏低。当前 `ecosystem.config.js` 默认 `instances=1`，问题不显现
- `DATA_SAVE_MODE=none`：`saveAllAccounts` 返回 false，历史不持久化。须设 `DATA_SAVE_MODE=file` 或 `redis` 才生效
- 00:00 后约 5 秒的短暂"凹陷"：reset 与 batch save 之间的微小时间窗。已通过深拷贝保护读取端

### 截图

`/statistics` 页面（中文 locale）：

![/statistics](https://raw.githubusercontent.com/weselow/Qwen2API/production/docs/images/statistics.png)

<details>
<summary><b>English version</b></summary>

I don't like to stop halfway, so I decided to finish per-account daily stats properly.

This is a follow-up to PR #114 (per-account daily stats). The problem: `chat`/`cli` counters are wiped by `_resetDailyCounters` at 00:00 every day, so yesterday's data is lost — no way to look back at trends.

This PR closes the loop end-to-end (storage, API, UI):

- a 90-day rolling per-account history (`account.statsHistory`, keyed by YYYY-MM-DD)
- an admin-key-protected read endpoint `GET /api/statsHistory`
- an optional, env-flag-protected debug endpoint (for smoke-testing first deploys)
- a new `/statistics` page that reuses the existing vue-i18n / LangSwitcher / glassmorphism setup

### What changed

**Storage + archival** (d435426)
- `ensureStats()` initializes `statsHistory = {}` for legacy records (backward-compat)
- `_resetDailyCounters()` now: prunes entries older than 90 days (string compare is valid for YYYY-MM-DD), snapshots yesterday if any counter was non-zero (empty days are intentionally skipped), then zeroes today
- Wrapped in a single `saveAllAccounts` batch (one `data.json` rewrite in file mode; sequential HSETs in redis mode)
- `data-persistence.js` and `redis.js` extend the existing MERGE semantics of the `stats` field to the new `statsHistory` field
- Public `getTodayKey()` helper pairs with the internal `_getYesterdayKey`; consumers must use it instead of `new Date()` so browser/container TZs cannot shift month boundaries

**Read API + debug endpoint** (8161b7a)
- `GET /api/statsHistory` returns `{today, accounts:[{email, history}]}`, with today merged from the live `account.stats` to avoid an empty UI on day-1
- Deep copy of `history` and `chat`/`cli` protects against concurrent `_resetDailyCounters` mutations within the ~5 s window at 00:00
- `POST /api/debug/archiveYesterday` is registered ONLY when `ENABLE_STATS_DEBUG_ARCHIVE === 'true'`. `NODE_ENV` is intentionally NOT used — this repo doesn't set it (`start.js`, `ecosystem.config.js`), so `'production'` can't be relied on. In any normal config the route is absent; verify with `-X POST` because GET on unknown paths falls into `app.get('*')` and returns the SPA with status 200

**Frontend** (0ec09b3)
- New lazy route `/statistics` with the auth guard updated to match
- `views/statistics.vue`: period filter (currentMonth / prevMonth / last90) + totals card + per-account cards. Date ranges are always derived from `response.data.today`, validated with a strict `^\d{4}-\d{2}-\d{2}$` regex, never via `new Date()` — so differing browser/container TZs cannot shift month boundaries
- Hybrid rendering: one Chart.js bar chart for the aggregate (legend, tooltips), pure-SVG `<polyline>` sparklines (~40 lines) for per-account cards so 30+ cards stay instant
- New components: `StatsTotals.vue`, `StatsAccountCard.vue`, `StatsBarChart.vue` (thin vue-chartjs Bar wrapper that registers the Chart.js modules it needs), `SvgSparkline.vue` (zero deps)
- Utility: `formatCompact(n, {unitK, unitM})` extracted from `dashboard.vue` into `public/src/utils/format.js`. Units are passed explicitly so the utility stays vue-i18n-agnostic — callers supply `t('dash.acct.unitK')` / `t('dash.acct.unitM')`
- i18n: `locales/{ru,zh}.json` gain a `stats.*` namespace + `dash.statistics`, key parity verified across both
- Dashboard header: new "Statistics" button routing to `/statistics`, plus a small reorganization — the six action buttons become a 3+3 grid on desktop (2 columns on mobile) with the language switcher pulled out. Previously "Force refresh" wrapped onto two lines on mid-width screens
- Dependencies: `chart.js@^4`, `vue-chartjs@^5`. The full Chart.js stack is only loaded when `/statistics` is visited (lazy route), so the main dashboard bundle is unaffected (statistics chunk 57 KB gzip; main index 80 KB gzip)

### Known limitations

- `PM2_INSTANCES > 1`: each worker keeps its own in-memory stats copy; archive totals would be under-reported proportionally. Default `ecosystem.config.js` sets `instances=1`, so this isn't triggered.
- `DATA_SAVE_MODE=none`: `saveAllAccounts` returns false, history isn't persisted. Set `DATA_SAVE_MODE=file` or `redis`.
- ~5 s sag once per day between the reset and the batch save. The read path is protected via deep copy.

### Screenshot

The `/statistics` page (Chinese locale):

![/statistics](https://raw.githubusercontent.com/weselow/Qwen2API/production/docs/images/statistics.png)

</details>