### PR TITLE
支持持久化apikey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pkg_dist/*
 pkg_dist/
 .idea
 /public/dist
+.vscode

--- a/src/routes/settings.js
+++ b/src/routes/settings.js
@@ -45,7 +45,9 @@ router.post('/addRegularKey', adminKeyVerify, async (req, res) => {
     // 添加到配置中
     config.apiKeys.push(apiKey)
 
-    res.json({ message: 'API Key添加成功' })
+    const persisted = await dataPersistence.saveSettings({ apiKeys: config.apiKeys })
+
+    res.json({ message: 'API Key添加成功', persisted })
   } catch (error) {
     logger.error('添加API Key失败', 'CONFIG', '', error)
     res.status(500).json({ error: error.message })
@@ -73,7 +75,9 @@ router.post('/deleteRegularKey', adminKeyVerify, async (req, res) => {
 
     config.apiKeys.splice(index, 1)
 
-    res.json({ message: 'API Key删除成功' })
+    const persisted = await dataPersistence.saveSettings({ apiKeys: config.apiKeys })
+
+    res.json({ message: 'API Key删除成功', persisted })
   } catch (error) {
     logger.error('删除API Key失败', 'CONFIG', '', error)
     res.status(500).json({ error: error.message })

--- a/src/server.js
+++ b/src/server.js
@@ -80,6 +80,10 @@ const applyPersistedSettings = async () => {
       const v = parseInt(persisted.chatRetryBackoffMs, 10)
       if (!isNaN(v) && v >= 0) config.chatRetryBackoffMs = v
     }
+    if (persisted.apiKeys?.length > 1) {
+      config.apiKeys = persisted.apiKeys;
+      config.adminKey = persisted.apiKeys[0];
+    }
   } catch (err) {
     logger.warn('加载持久化设置失败, 使用 env/默认值', 'CONFIG', '', err.message)
   }

--- a/src/utils/redis.js
+++ b/src/utils/redis.js
@@ -493,7 +493,7 @@ const getSettings = async () => {
   try {
     const client = await ensureConnection()
     const data = await client.hgetall(SETTINGS_KEY)
-    return data && Object.keys(data).length > 0 ? data : {}
+    return JSON.parse(data.json)
   } catch (err) {
     logger.error('获取运行时设置失败', 'REDIS', '', err)
     return {}
@@ -508,11 +508,9 @@ const getSettings = async () => {
 const setSettings = async (partial) => {
   try {
     const client = await ensureConnection()
-    const stringified = {}
-    for (const [k, v] of Object.entries(partial || {})) {
-      stringified[k] = v === null || v === undefined ? '' : String(v)
+    const stringified = {
+      json: JSON.stringify(partial)
     }
-    if (Object.keys(stringified).length === 0) return true
     await client.hset(SETTINGS_KEY, stringified)
     return true
   } catch (err) {


### PR DESCRIPTION
以前普通密钥在服务器重启之后就会丢失，现在增加持久化保存。

为了改动最小化，避免想要保存新的东西就定义一个`dataPersistence.savaXXX`，调用`dataPersistence.saveSettings`一起保存到`settings`下面。

在`file`模式下，这很容易。

但是`redis`模式下，原来的方式保存对象会有问题，所以我也修改了Redis版本的持久化方法，以json方式保存整个`settings`对象。如果支持这次改动，其他的选项也轻易做到持久化。

下面是持久化后的效果：

<img width="519" height="355" alt="image" src="https://github.com/user-attachments/assets/01b26ef0-b888-4a03-8623-10dac515a045" />

<img width="1005" height="160" alt="image" src="https://github.com/user-attachments/assets/e8201367-c035-4aaf-b68e-727ec6f5629f" />
