### PR TITLE
完善 Anthropic 兼容性并缩短 CLI 失败重试，增加CLI不可用的账号状态显示

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -547,7 +547,9 @@ OpenAI SDK, LangChain, Cline, Continue, and other clients following OpenAI tool 
 
 ### 🤖 Anthropic Messages API
 
-Compatible with Anthropic's `/v1/messages` endpoint, can directly connect to Claude Code, Anthropic SDK, aider, and other clients.
+Provides an **Anthropic-compatible bridge** for the `/v1/messages` endpoint, allowing direct use with common clients such as Claude Code, the Anthropic SDK, and aider.
+
+> Note: Qwen2API is a compatibility bridge, not an Anthropic-equivalent backend. For unsupported fields, the current strategy is intentionally **permissive**: the request is accepted whenever possible, and important unsupported fields are surfaced through response headers and server logs instead of being silently ignored. Fields such as `system`, multi-turn `messages`, `tools`, `tool_choice`, and `thinking` are currently **approximate compatibility**, not native Anthropic semantics.
 
 ```http
 POST /v1/messages
@@ -555,17 +557,37 @@ Content-Type: application/json
 Authorization: Bearer sk-your-api-key
 ```
 
-Supported fields:
+**Compatibility matrix:**
 
-| Field | Description |
-|---|---|
-| [model](file://d:\Code\Qwen2API\src\controllers\anthropic.js#L238-L238) | Any Qwen model name (like `qwen3-coder-plus`) |
-| `system` | String or `{type:"text"}` block array |
-| `messages[].content` | String, text blocks, image blocks, `tool_use` blocks, `tool_result` blocks |
-| `tools[]` | Anthropic style `{name,input_schema,description}` |
-| `tool_choice` | `{type:"auto"}` / `{type:"any"}` (=must call) / `{type:"tool",name:"..."}` / `{type:"none"}` |
-| `thinking` | `{type:"enabled",budget_tokens:N}` enables thinking mode |
-| [stream](file://d:\Code\Qwen2API\src\controllers\anthropic.js#L233-L233) | Streaming SSE output |
+| Field / capability | Status | Current behavior | Notes / client impact |
+|---|---|---|---|
+| `model` | Supported | Mapped to a Qwen model name | Any resolvable Qwen model ID can be used |
+| `messages.text` | Supported | Supports basic text messages | Standard chat clients work |
+| `messages.image` | Supported | Supports image blocks and translates them into the internal image format | Suitable for common multimodal clients |
+| `messages.tool_use` | Partial | Accepts Anthropic-style `tool_use` history blocks, then translates/folds them internally | Not native upstream tool-call semantics |
+| `messages.tool_result` | Partial | Accepts `tool_result` and converts it into bridge-layer tool-result text | Details such as `is_error` are not guaranteed to be preserved |
+| `system` | Partial | Merged into the prompt prefix | Not preserved as a native upstream system layer |
+| `messages` (multi-turn) | Partial | Multi-turn history is compacted / translated | Structured conversation semantics are approximate |
+| `tools[]` | Partial | Supports the basic `{name,input_schema,description}` shape | Implemented through prompt/XML simulation, not native upstream tool execution |
+| `tool_choice` | Partial | Supports the basic `auto` / `any` / `tool` / `none` modes | Relies on prompt steering and retry hints, not an upstream hard guarantee |
+| `thinking` | Partial | Currently accepts legacy `thinking: {type:"enabled", budget_tokens:N}` and maps it approximately | Not equivalent to Anthropic's newer adaptive thinking / effort semantics |
+| `stream` | Supported | Returns an Anthropic-style SSE event sequence | Suitable for Claude Code and other streaming clients |
+| `max_tokens` | Ignored with warning | Currently does not enforce an upstream output limit | Exposed through warning headers / logs |
+| `stop_sequences` | Ignored with warning | Not currently mapped to upstream stop behavior | Exposed through warning headers / logs |
+| `metadata` | Ignored with warning | Not used in the upstream request | Exposed through warning headers / logs |
+| `temperature` / `top_p` / `top_k` | Ignored with warning | Not currently mapped to upstream sampling controls | Exposed through warning headers / logs |
+| `service_tier` | Ignored with warning | Not supported | Exposed through warning headers / logs |
+| `container` | Ignored with warning | Not supported | Exposed through warning headers / logs |
+| `output_config` | Ignored with warning | Does not currently support official structured outputs / effort semantics | Exposed through warning headers / logs |
+| `mcp_servers` | Not supported yet | Anthropic MCP runtime semantics are not supported | Currently surfaced as a risk warning; a later version may convert this into an explicit error |
+| `context_management` | Not supported yet | Official compaction / context-editing semantics are not supported | Currently surfaced as a risk warning; a later version may convert this into an explicit error |
+
+When a request includes approximate or unsupported fields, the response may include these headers:
+
+- `X-Qwen2API-Anthropic-Compatibility`
+- `X-Qwen2API-Anthropic-Warnings`
+
+These headers indicate which Anthropic capabilities are **Partial** and which fields were **Ignored with warning**. They do not change the basic successful response body shape.
 
 **Request Example (with tool calling):**
 
@@ -586,9 +608,11 @@ Supported fields:
       }
     }
   ],
-  "tool_choice": { "type:"any" }
+  "tool_choice": { "type": "any" }
 }
 ```
+
+> Note: `max_tokens` is accepted in the example above, but it is currently **Ignored with warning** and does not enforce an upstream output limit the way the official Anthropic API does.
 
 **Non-streaming Response:**
 

--- a/README-ru.md
+++ b/README-ru.md
@@ -503,6 +503,119 @@ Authorization: Bearer sk-your-api-key
 }
 ```
 
+### 🤖 Anthropic Messages API
+
+Проект предоставляет **Anthropic-compatible bridge** для конечной точки `/v1/messages`, чтобы её можно было использовать с такими клиентами, как Claude Code, Anthropic SDK, aider и другими совместимыми инструментами.
+
+> Примечание: Qwen2API — это слой совместимости, а не эквивалентный официальный backend Anthropic. Для неподдерживаемых полей текущая стратегия намеренно **мягкая**: запрос по возможности принимается, а важные неподдерживаемые поля явно показываются через response headers и серверные логи, вместо того чтобы молча игнорироваться. Поля `system`, многоходовые `messages`, `tools`, `tool_choice` и `thinking` сейчас поддерживаются **приближённо**, а не как нативная семантика Anthropic.
+
+```http
+POST /v1/messages
+Content-Type: application/json
+Authorization: Bearer sk-your-api-key
+```
+
+**Матрица совместимости:**
+
+| Поле / возможность | Статус | Текущее поведение | Примечание / влияние на клиента |
+|---|---|---|---|
+| `model` | Supported | Сопоставляется с именем модели Qwen | Можно использовать любой разрешаемый ID модели Qwen |
+| `messages.text` | Supported | Поддерживаются обычные текстовые сообщения | Базовые chat-клиенты работают |
+| `messages.image` | Supported | Поддерживаются image-блоки с переводом во внутренний формат изображений | Подходит для типичных мультимодальных клиентов |
+| `messages.tool_use` | Partial | Принимаются Anthropic-style блоки истории `tool_use`, затем они переводятся и сворачиваются внутри bridge | Это не нативная upstream-семантика tool call |
+| `messages.tool_result` | Partial | Принимается `tool_result`, затем преобразуется в текстовый результат bridge-слоя | Детали вроде `is_error` не гарантированно сохраняются |
+| `system` | Partial | Встраивается в префикс prompt | Не сохраняется как отдельный нативный system-слой upstream |
+| `messages` (multi-turn) | Partial | История нескольких ходов сжимается / переводится | Семантика структурированного диалога приблизительная |
+| `tools[]` | Partial | Поддерживается базовая форма `{name,input_schema,description}` | Реализовано через prompt/XML-симуляцию, а не нативное upstream tool execution |
+| `tool_choice` | Partial | Поддерживаются базовые режимы `auto` / `any` / `tool` / `none` | Опирается на prompt steering и retry hints, а не на жёсткую гарантию upstream |
+| `thinking` | Partial | Сейчас принимается legacy-форма `thinking: {type:"enabled", budget_tokens:N}` и приблизительно отображается | Не эквивалентно новым adaptive thinking / effort semantics Anthropic |
+| `stream` | Supported | Возвращает Anthropic-style SSE последовательность событий | Подходит для Claude Code и других streaming-клиентов |
+| `max_tokens` | Ignored with warning | Сейчас не ограничивает upstream output по-настоящему | Показывается через warning headers / logs |
+| `stop_sequences` | Ignored with warning | Сейчас не отображается на upstream stop behavior | Показывается через warning headers / logs |
+| `metadata` | Ignored with warning | Сейчас не участвует в upstream-запросе | Показывается через warning headers / logs |
+| `temperature` / `top_p` / `top_k` | Ignored with warning | Сейчас не переводится в upstream sampling controls | Показывается через warning headers / logs |
+| `service_tier` | Ignored with warning | Сейчас не поддерживается | Показывается через warning headers / logs |
+| `container` | Ignored with warning | Сейчас не поддерживается | Показывается через warning headers / logs |
+| `output_config` | Ignored with warning | Сейчас не поддерживаются official structured outputs / effort semantics | Показывается через warning headers / logs |
+| `mcp_servers` | Not supported yet | Anthropic MCP runtime semantics сейчас не поддерживаются | Пока только помечается как риск; в будущей версии может стать явной ошибкой |
+| `context_management` | Not supported yet | Official compaction / context-editing semantics сейчас не поддерживаются | Пока только помечается как риск; в будущей версии может стать явной ошибкой |
+
+Если запрос содержит приближённо поддерживаемые или неподдерживаемые поля, в ответе могут появиться следующие headers:
+
+- `X-Qwen2API-Anthropic-Compatibility`
+- `X-Qwen2API-Anthropic-Warnings`
+
+Эти headers показывают, какие Anthropic-возможности имеют статус **Partial**, а какие поля были **Ignored with warning**. Они не меняют базовую форму успешного response body.
+
+**Пример запроса (с tool calling):**
+
+```json
+{
+  "model": "qwen3-coder-plus",
+  "max_tokens": 1024,
+  "messages": [
+    {"role": "user", "content": "Проверь погоду в Гуанчжоу"}
+  ],
+  "tools": [
+    {
+      "name": "get_weather",
+      "input_schema": {
+        "type": "object",
+        "properties": { "city": { "type": "string" } },
+        "required": ["city"]
+      }
+    }
+  ],
+  "tool_choice": { "type": "any" }
+}
+```
+
+> Примечание: `max_tokens` в примере выше принимается, но сейчас относится к **Ignored with warning** и не ограничивает upstream output так же, как это делает официальный Anthropic API.
+
+**Непотоковый ответ:**
+
+```json
+{
+  "id": "msg_xxx",
+  "type": "message",
+  "role": "assistant",
+  "model": "qwen3-coder-plus",
+  "content": [
+    {
+      "type": "tool_use",
+      "id": "call_xxx",
+      "name": "get_weather",
+      "input": { "city": "Гуанчжоу" }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "usage": { "input_tokens": 233, "output_tokens": 25 }
+}
+```
+
+**Последовательность SSE-событий в потоковом режиме:**
+
+```
+event: message_start
+data: {"type":"message_start","message":{...}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call_xxx","name":"get_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Гуанчжоу\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":234,"output_tokens":25}}
+
+event: message_stop
+data: {"type":"message_stop"}
+```
+
 ### 🎨 Генерация/редактирование изображений
 
 Используйте модели с суффиксом `-image` для генерации изображений из текста.

--- a/README.md
+++ b/README.md
@@ -547,7 +547,9 @@ OpenAI SDK、LangChain、Cline、Continue 等遵循 OpenAI 工具协议的客户
 
 ### 🤖 Anthropic Messages API
 
-兼容 Anthropic 的 `/v1/messages` 端点，可直接对接 Claude Code、Anthropic SDK、aider 等客户端。
+提供 **Anthropic-compatible bridge** 的 `/v1/messages` 端点，可直接对接 Claude Code、Anthropic SDK、aider 等常见客户端。
+
+> 说明：Qwen2API 是兼容桥接层，不是 Anthropic 官方等价实现。对未支持字段，本项目当前采用**尽量宽松**的策略：尽可能接受请求，并通过响应头与服务端日志显式提示，而不是继续静默忽略。对 `system`、多轮 `messages`、`tools`、`tool_choice`、`thinking` 等字段，当前为**近似兼容**，并非官方原生语义。
 
 ```http
 POST /v1/messages
@@ -555,17 +557,37 @@ Content-Type: application/json
 Authorization: Bearer sk-your-api-key
 ```
 
-支持的字段：
+**兼容矩阵：**
 
-| 字段 | 说明 |
-|---|---|
-| `model` | 任意 Qwen 模型名（如 `qwen3-coder-plus`） |
-| `system` | 字符串或 `{type:"text"}` 块数组 |
-| `messages[].content` | 字符串、文本块、图片块、`tool_use` 块、`tool_result` 块 |
-| `tools[]` | Anthropic 风格 `{name,input_schema,description}` |
-| `tool_choice` | `{type:"auto"}` / `{type:"any"}`（=必须调用） / `{type:"tool",name:"..."}` / `{type:"none"}` |
-| `thinking` | `{type:"enabled",budget_tokens:N}` 启用思考模式 |
-| `stream` | 流式 SSE 输出 |
+| 字段 / 能力 | 状态 | 当前行为 | 备注 / 客户端影响 |
+|---|---|---|---|
+| `model` | Supported | 映射到 Qwen 模型名 | 可用任意可解析的 Qwen 模型 ID |
+| `messages.text` | Supported | 支持基础文本消息 | 基础聊天可用 |
+| `messages.image` | Supported | 支持图片块并转译到内部图片格式 | 适合常见多模态客户端 |
+| `messages.tool_use` | Partial | 接收 Anthropic 风格 `tool_use` 历史块，但内部会转译并折叠 | 不是上游原生工具调用语义 |
+| `messages.tool_result` | Partial | 接收 `tool_result`，内部转为桥接层工具结果文本 | `is_error` 等细节不保证保真 |
+| `system` | Partial | 会被合并进提示前缀 | 不是独立的原生 system 层 |
+| `messages`（多轮） | Partial | 多轮历史会被压缩/转译 | 结构化上下文语义为近似兼容 |
+| `tools[]` | Partial | 支持基础 `{name,input_schema,description}` | 通过 prompt/XML 模拟，不是原生 upstream tool execution |
+| `tool_choice` | Partial | 支持 `auto` / `any` / `tool` / `none` 基础形态 | 依赖提示词与 retry hint，不是上游强保证 |
+| `thinking` | Partial | 当前接受旧式 `thinking: {type:"enabled", budget_tokens:N}` 并近似映射 | 不等价官方新式 adaptive thinking / effort 语义 |
+| `stream` | Supported | 返回 Anthropic 风格 SSE 事件序列 | 适合 Claude Code 等流式客户端 |
+| `max_tokens` | Ignored with warning | 当前不会真实限制上游输出 | 会通过 warning headers / logs 显式提示 |
+| `stop_sequences` | Ignored with warning | 当前未映射到上游停止序列 | 会通过 warning headers / logs 显式提示 |
+| `metadata` | Ignored with warning | 当前不参与上游请求 | 会通过 warning headers / logs 显式提示 |
+| `temperature` / `top_p` / `top_k` | Ignored with warning | 当前不参与上游采样控制 | 会通过 warning headers / logs 显式提示 |
+| `service_tier` | Ignored with warning | 当前不支持 | 会通过 warning headers / logs 显式提示 |
+| `container` | Ignored with warning | 当前不支持 | 会通过 warning headers / logs 显式提示 |
+| `output_config` | Ignored with warning | 当前不支持 structured outputs / effort 等官方语义 | 会通过 warning headers / logs 显式提示 |
+| `mcp_servers` | Not supported yet | 当前不支持 Anthropic MCP runtime 语义 | 当前仅提示风险，后续版本可能改为显式报错 |
+| `context_management` | Not supported yet | 当前不支持 compaction / context editing 等官方语义 | 当前仅提示风险，后续版本可能改为显式报错 |
+
+当请求包含近似支持或未支持字段时，响应可能带有以下 header：
+
+- `X-Qwen2API-Anthropic-Compatibility`
+- `X-Qwen2API-Anthropic-Warnings`
+
+这些 header 用于提示当前请求中哪些 Anthropic 能力是 **Partial**、哪些字段被 **Ignored with warning**，不会改变成功响应 body 的基本结构。
 
 **请求示例（含工具调用）：**
 
@@ -589,6 +611,8 @@ Authorization: Bearer sk-your-api-key
   "tool_choice": { "type": "any" }
 }
 ```
+
+> 注意：上例中的 `max_tokens` 当前会被接受，但仍属于 **Ignored with warning**，不会像官方 Anthropic API 那样真实约束上游输出。
 
 **非流式响应：**
 

--- a/public/src/locales/en.json
+++ b/public/src/locales/en.json
@@ -11,10 +11,12 @@
       "chatToday": "Chat Today",
       "cliSuccess": "success",
       "cliToday": "CLI Today",
+      "cliUnavailableShort": "Unavailable",
       "status": {
         "active": "active",
         "cooldown": "Cooling down ({until} remaining)",
         "tokenExpiring": "Token is about to expire",
+        "cliUnsupported": "CLI calling is not supported",
         "unitMin": "point",
         "unitSec": "Second",
         "warn": "There were recent errors ({code}, {ago} ago)",

--- a/public/src/locales/ru.json
+++ b/public/src/locales/ru.json
@@ -65,6 +65,7 @@
       "chatToday": "Chat (сегодня)",
       "cliToday": "CLI (сегодня)",
       "calls": "запросов",
+      "cliUnavailableShort": "Недоступно",
       "cliSuccess": "успешно",
       "unitK": "к",
       "unitM": "M",
@@ -74,6 +75,7 @@
         "warnNoCode": "Недавние ошибки ({ago} назад)",
         "cooldown": "В охлаждении (осталось {until})",
         "tokenExpiring": "Токен скоро истекает",
+        "cliUnsupported": "CLI-вызовы не поддерживаются",
         "unitSec": "сек",
         "unitMin": "мин"
       }

--- a/public/src/locales/zh.json
+++ b/public/src/locales/zh.json
@@ -65,6 +65,7 @@
       "chatToday": "今日 Chat",
       "cliToday": "今日 CLI",
       "calls": "次调用",
+      "cliUnavailableShort": "不可用",
       "cliSuccess": "成功",
       "unitK": "k",
       "unitM": "M",
@@ -74,6 +75,7 @@
         "warnNoCode": "最近有错误 ({ago}前)",
         "cooldown": "冷却中 (剩余 {until})",
         "tokenExpiring": "Token 即将过期",
+        "cliUnsupported": "不支持 CLI 调用",
         "unitSec": "秒",
         "unitMin": "分"
       }

--- a/public/src/views/dashboard.vue
+++ b/public/src/views/dashboard.vue
@@ -224,19 +224,31 @@
                     out
                   </span>
                 </div>
-                <button type="button"
+                <template v-if="getStatusKind(token.email) === 'cli_unsupported'">
+                  <div class="flex items-baseline justify-between gap-2 w-full text-left">
+                    <span class="text-gray-400 border-b border-dotted border-gray-300 transition-colors"
+                          :title="getStatusTooltip(token.email)">
+                      {{ t('dash.acct.cliToday') }}:
+                    </span>
+                    <span class="font-medium text-gray-400 text-xs md:text-sm"
+                          :title="getStatusTooltip(token.email)">
+                      {{ t('dash.acct.cliUnavailableShort') }}
+                    </span>
+                  </div>
+                </template>
+                <button v-else type="button"
                         @click="toggleCliExpanded"
                         class="flex items-baseline justify-between gap-2 w-full text-left focus:outline-none">
                   <span class="text-gray-600 border-b border-dotted border-gray-400 hover:text-gray-800 transition-colors">
                     {{ t('dash.acct.cliToday') }}:
                   </span>
                   <span class="font-medium text-gray-800 text-xs md:text-sm flex items-center gap-1">
-                    <span>{{ getCliRequestNumber(token.email) }} / {{ cliQuotaLimit }} {{ t('dash.acct.calls') }}</span>
+                    <span>{{ getCliRequestNumber(token.email) }} / {{ getCliQuotaLimit(token.email) }} {{ t('dash.acct.calls') }}</span>
                     <span class="text-xs text-gray-400 transition-transform duration-200" :class="{ 'rotate-90': cliExpanded }">▸</span>
                   </span>
                 </button>
                 <transition name="fade">
-                  <div v-if="cliExpanded" class="space-y-1 pt-1">
+                  <div v-if="cliExpanded && getStatusKind(token.email) !== 'cli_unsupported'" class="space-y-1 pt-1">
                     <div class="text-xs text-gray-500 text-right">
                       {{ t('dash.acct.cliSuccess') }}: {{ getAccountStats(token.email).cli.calls }}
                     </div>
@@ -597,8 +609,14 @@ const DEFAULT_STATS = Object.freeze({
 
 const getAccountStats = (email) => accountStats.value[email]?.stats || DEFAULT_STATS
 const getCliRequestNumber = (email) => accountStats.value[email]?.cliRequestNumber || 0
+const getCliQuotaLimit = (email) => {
+  const perAccountLimit = accountStats.value[email]?.cliQuotaLimit
+  if (typeof perAccountLimit === 'number') return perAccountLimit
+  return cliQuotaLimit.value
+}
 const getCliProgressPct = (email) => {
-  const limit = cliQuotaLimit.value || 2000
+  const limit = getCliQuotaLimit(email)
+  if (limit <= 0) return 0
   return Math.min(100, getCliRequestNumber(email) / limit * 100)
 }
 const getCliProgressColor = (email) => {
@@ -624,7 +642,8 @@ const STATUS_EMOJI = Object.freeze({
   active: '🟢',
   warn: '🟡',
   cooldown: '🔴',
-  token_expiring: '🪫'
+  token_expiring: '🪫',
+  cli_unsupported: '⚪'
 })
 const nowTick = ref(Date.now())
 let tickInterval = null
@@ -674,6 +693,9 @@ const getStatusTooltip = (email) => {
   if (kind === 'token_expiring') {
     return t('dash.acct.status.tokenExpiring')
   }
+  if (kind === 'cli_unsupported') {
+    return t('dash.acct.status.cliUnsupported')
+  }
   return t('dash.acct.status.active')
 }
 
@@ -687,7 +709,7 @@ const fetchAccountStats = async () => {
       if (entry?.email) map[entry.email] = entry
     }
     accountStats.value = map
-    if (typeof res.data?.cliQuotaLimit === 'number' && res.data.cliQuotaLimit > 0) {
+    if (typeof res.data?.cliQuotaLimit === 'number') {
       cliQuotaLimit.value = res.data.cliQuotaLimit
     }
     // Drop suppression entries where account is no longer in cooldown OR

--- a/src/controllers/anthropic.compatibility.js
+++ b/src/controllers/anthropic.compatibility.js
@@ -1,0 +1,95 @@
+const SUPPORTED_FIELDS = new Set([
+  'model',
+  'messages',
+  'stream'
+]);
+
+const PARTIAL_FIELDS = new Set([
+  'system',
+  'tools',
+  'tool_choice',
+  'thinking'
+]);
+
+const IGNORED_WITH_WARNING_FIELDS = new Set([
+  'max_tokens',
+  'stop_sequences',
+  'metadata',
+  'temperature',
+  'top_p',
+  'top_k',
+  'service_tier',
+  'container',
+  'output_config',
+  'cache_control'
+]);
+
+const FUTURE_RISK_FIELDS = new Set([
+  'mcp_servers',
+  'context_management'
+]);
+
+const analyzeAnthropicCompatibility = (requestBody = {}) => {
+  const keys = Object.keys(requestBody || {});
+  const supportedFields = [];
+  const partialFields = [];
+  const ignoredFields = [];
+  const futureRiskFields = [];
+
+  for (const key of keys) {
+    if (SUPPORTED_FIELDS.has(key)) {
+      supportedFields.push(key);
+    } else if (PARTIAL_FIELDS.has(key)) {
+      partialFields.push(key);
+    } else if (IGNORED_WITH_WARNING_FIELDS.has(key)) {
+      ignoredFields.push(key);
+    } else if (FUTURE_RISK_FIELDS.has(key)) {
+      futureRiskFields.push(key);
+    }
+  }
+
+  const summaryParts = [];
+  if (partialFields.length > 0) {
+    summaryParts.push(`partial=${partialFields.join(',')}`);
+  }
+  if (ignoredFields.length > 0) {
+    summaryParts.push(`ignored=${ignoredFields.join(',')}`);
+  }
+  if (futureRiskFields.length > 0) {
+    summaryParts.push(`future_risk=${futureRiskFields.join(',')}`);
+  }
+
+  return {
+    supportedFields,
+    partialFields,
+    ignoredFields,
+    futureRiskFields,
+    summary: summaryParts.join(';')
+  };
+};
+
+const buildAnthropicCompatibilityHeaders = ({ partialFields = [], ignoredFields = [], futureRiskFields = [] } = {}) => {
+  const headers = {};
+
+  if (partialFields.length > 0 || futureRiskFields.length > 0) {
+    const compatibilityParts = [];
+    if (partialFields.length > 0) {
+      compatibilityParts.push(`partial=${partialFields.join(',')}`);
+    }
+    if (futureRiskFields.length > 0) {
+      compatibilityParts.push(`future_risk=${futureRiskFields.join(',')}`);
+    }
+    headers['X-Qwen2API-Anthropic-Compatibility'] = compatibilityParts.join(';');
+  }
+
+  if (ignoredFields.length > 0) {
+    headers['X-Qwen2API-Anthropic-Warnings'] = `ignored=${ignoredFields.join(',')}`;
+  }
+
+  return headers;
+};
+
+module.exports = {
+  analyzeAnthropicCompatibility,
+  buildAnthropicCompatibilityHeaders
+};

--- a/src/controllers/anthropic.js
+++ b/src/controllers/anthropic.js
@@ -10,6 +10,10 @@ const {
   createToolCallStreamParser
 } = require('../utils/tool-prompt.js');
 const { logger } = require('../utils/logger');
+const {
+  analyzeAnthropicCompatibility,
+  buildAnthropicCompatibilityHeaders
+} = require('./anthropic.compatibility.js');
 
 /**
  * 安全累计 chat stats（与 chat.js attributeChatUsage 共享语义）
@@ -699,6 +703,16 @@ const handleAnthropicNonStream = async (res, ctx, upstream) => {
  */
 const handleAnthropicMessages = async (req, res) => {
   try {
+    const compatibility = analyzeAnthropicCompatibility(req.body || {});
+    const compatibilityHeaders = buildAnthropicCompatibilityHeaders(compatibility);
+    if (Object.keys(compatibilityHeaders).length > 0) {
+      res.set(compatibilityHeaders);
+      logger.warn(
+        `Anthropic compatibility notice: ${compatibility.summary}`,
+        'ANTHROPIC'
+      );
+    }
+
     const built = await buildInternalRequest(req.body || {});
     const { body, hasTools, toolChoice, model } = built;
 
@@ -733,6 +747,8 @@ const handleAnthropicMessages = async (req, res) => {
 
 module.exports = {
   handleAnthropicMessages,
+  analyzeAnthropicCompatibility,
+  buildAnthropicCompatibilityHeaders,
   // 暴露内部辅助以便测试
   flattenAnthropicMessages,
   normalizeAnthropicTools,

--- a/src/routes/accounts.js
+++ b/src/routes/accounts.js
@@ -8,6 +8,7 @@ const { adminKeyVerify } = require('../middlewares/authorization')
 const { deleteAccount, saveAccounts, refreshAccountToken } = require('../utils/setting')
 const { parseAccountLine } = require('../utils/account-parser')
 const { isValidProxyUrl } = require('../utils/proxy-helper')
+const { DEFAULT_CLI_QUOTA_LIMIT, getAccountCliState } = require('../utils/cli-support')
 
 // 仅在 proxy 字段存在时触发；空字符串/null 一律视为"清除代理"，无需校验
 const PROXY_FORMAT_ERROR = '代理 URL 格式无效，应以 http://、https:// 或 socks5:// 开头'
@@ -624,12 +625,6 @@ router.post('/forceRefreshAllAccounts', adminKeyVerify, async (req, res) => {
 router.get('/accountStats', adminKeyVerify, async (req, res) => {
   try {
     const now = Date.now()
-    // 15 分钟 warn 窗口——recordError 写 lastErrorAt 后, UI 显示 🟡 warn 一段时间
-    const WARN_WINDOW_MS = 15 * 60 * 1000
-    // 6 小时——与 tokenManager.isTokenExpiringSoon default 一致
-    const TOKEN_EXPIRING_MS = 6 * 60 * 60 * 1000
-    // CLI 每日配额（与 routes/cli.chat.js:22 同步，dashboard 进度条用）
-    const CLI_QUOTA_LIMIT = 2000
 
     const rotatorStats = accountManager.accountRotator.getStats()
     const usageStats = rotatorStats.usageStats || {}
@@ -637,38 +632,21 @@ router.get('/accountStats', adminKeyVerify, async (req, res) => {
     const accounts = accountManager.getAllAccountKeys().map(account => {
       const email = account.email
       const rotatorRecord = usageStats[email] || {}
-      const cooldownEndsAt = rotatorRecord.cooldownEndsAt || null
-      const lastErrorAt = rotatorRecord.lastErrorAt || null
-      const lastErrorCode = rotatorRecord.lastErrorCode || null
-
-      // 优先级：cooldown > warn > token_expiring > active
-      let kind = 'active'
-      if (cooldownEndsAt && now < cooldownEndsAt) {
-        kind = 'cooldown'
-      } else if (lastErrorAt && (now - lastErrorAt) < WARN_WINDOW_MS) {
-        kind = 'warn'
-      } else if (account.expires && (account.expires * 1000 - now) < TOKEN_EXPIRING_MS) {
-        // account.expires 是 UNIX seconds（JWT exp 直接保存）——*1000 得到 ms
-        // 直接对比 timestamp, 不调用 isTokenExpiringSoon(token)（后者接受 token 字符串而非 expires）
-        kind = 'token_expiring'
-      }
+      const cliState = getAccountCliState(account, rotatorRecord, now)
 
       return {
         email,
-        stats: account.stats || { chat: { input: 0, output: 0 }, cli: { calls: 0, input: 0, output: 0 } },
-        cliRequestNumber: account.cli_info?.request_number || 0,
-        status: {
-          kind,
-          cooldownEndsAt,
-          lastErrorAt,
-          lastErrorCode
-        }
+        ...cliState
       }
     })
 
+    const cliQuotaLimit = accounts.some(account => account.cliQuotaLimit === DEFAULT_CLI_QUOTA_LIMIT)
+      ? DEFAULT_CLI_QUOTA_LIMIT
+      : 0
+
     res.json({
       accounts,
-      cliQuotaLimit: CLI_QUOTA_LIMIT
+      cliQuotaLimit
     })
   } catch (error) {
     logger.error('获取账户 stats 失败', 'ACCOUNT', '', error)

--- a/src/routes/cli.chat.js
+++ b/src/routes/cli.chat.js
@@ -3,12 +3,13 @@ const router = express.Router()
 const { apiKeyVerify } = require('../middlewares/authorization.js')
 const { handleCliChatCompletion } = require('../controllers/cli.chat.js')
 const accountManager = require('../utils/account.js')
+const { DEFAULT_CLI_QUOTA_LIMIT } = require('../utils/cli-support.js')
 
 router.post('/cli/v1/chat/completions',
     apiKeyVerify,
     async (req, res, next) => {
         // 异步初始化新账号（不阻塞当前请求）
-        const noCliAccount = accountManager.accountTokens.filter(account => !account.cli_info)
+        const noCliAccount = accountManager.accountTokens.filter(account => !account.cli_info && account.cli_unavailable_reason !== 'unsupported')
         if (noCliAccount.length > 0) {
             const randomNewAccount = noCliAccount[Math.floor(Math.random() * noCliAccount.length)]
             // 异步初始化，不等待结果
@@ -19,7 +20,7 @@ router.post('/cli/v1/chat/completions',
 
         // 获取当前可用的CLI账户用于本次请求
         const availableAccounts = accountManager.accountTokens.filter(account =>
-            account.cli_info && account.cli_info.request_number < 2000
+            account.cli_info && account.cli_info.request_number < DEFAULT_CLI_QUOTA_LIMIT
         )
 
         if (availableAccounts.length === 0) {

--- a/src/utils/account.js
+++ b/src/utils/account.js
@@ -205,6 +205,7 @@ class Account {
             const cliAccount = await cliManager.initCliAccount(account.token, account)
 
             if (cliAccount.access_token && cliAccount.refresh_token && cliAccount.expiry_date) {
+                account.cli_unavailable_reason = null
                 account.cli_info = {
                     access_token: cliAccount.access_token,
                     refresh_token: cliAccount.refresh_token,
@@ -231,6 +232,8 @@ class Account {
                 }
                 logger.success(`CLI账户 ${account.email} 初始化成功`, 'CLI')
             } else {
+                account.cli_info = null
+                account.cli_unavailable_reason = 'unsupported'
                 logger.error(`CLI账户 ${account.email} 初始化失败：无效的响应数据`, 'CLI', '', cliAccount)
             }
         } catch (error) {

--- a/src/utils/cli-support.js
+++ b/src/utils/cli-support.js
@@ -1,0 +1,40 @@
+const DEFAULT_CLI_QUOTA_LIMIT = 2000
+
+function getAccountCliState(account, rotatorRecord = {}, now = Date.now()) {
+  const WARN_WINDOW_MS = 15 * 60 * 1000
+  const TOKEN_EXPIRING_MS = 6 * 60 * 60 * 1000
+
+  const cooldownEndsAt = rotatorRecord.cooldownEndsAt || null
+  const lastErrorAt = rotatorRecord.lastErrorAt || null
+  const lastErrorCode = rotatorRecord.lastErrorCode || null
+  const cliUnavailableReason = account.cli_unavailable_reason || null
+
+  let kind = 'active'
+  if (cliUnavailableReason === 'unsupported') {
+    kind = 'cli_unsupported'
+  } else if (cooldownEndsAt && now < cooldownEndsAt) {
+    kind = 'cooldown'
+  } else if (lastErrorAt && (now - lastErrorAt) < WARN_WINDOW_MS) {
+    kind = 'warn'
+  } else if (account.expires && (account.expires * 1000 - now) < TOKEN_EXPIRING_MS) {
+    kind = 'token_expiring'
+  }
+
+  return {
+    stats: account.stats || { chat: { input: 0, output: 0 }, cli: { calls: 0, input: 0, output: 0 } },
+    cliRequestNumber: account.cli_info?.request_number || 0,
+    cliQuotaLimit: kind === 'cli_unsupported' ? 0 : DEFAULT_CLI_QUOTA_LIMIT,
+    status: {
+      kind,
+      cooldownEndsAt,
+      lastErrorAt,
+      lastErrorCode,
+      cliUnavailableReason
+    }
+  }
+}
+
+module.exports = {
+  DEFAULT_CLI_QUOTA_LIMIT,
+  getAccountCliState
+}

--- a/src/utils/cli.manager.js
+++ b/src/utils/cli.manager.js
@@ -180,7 +180,7 @@ class CliAuthManager {
      */
     async pollForToken(device_code, code_verifier, account) {
         let pollInterval = 5000
-        const maxAttempts = 60
+        const maxAttempts = 3
         const chatBaseUrl = getChatBaseUrl()
 
         for (let attempt = 0; attempt < maxAttempts; attempt++) {

--- a/tests/anthropic.compatibility.test.js
+++ b/tests/anthropic.compatibility.test.js
@@ -1,0 +1,54 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const compatibility = require('../src/controllers/anthropic.compatibility.js');
+
+test('analyzeAnthropicCompatibility classifies supported partial ignored and future-risk fields', () => {
+  assert.equal(typeof compatibility.analyzeAnthropicCompatibility, 'function');
+
+  const result = compatibility.analyzeAnthropicCompatibility({
+    model: 'qwen3-coder-plus',
+    messages: [{ role: 'user', content: 'hello' }],
+    system: 'You are helpful',
+    tools: [{ name: 'foo', input_schema: { type: 'object', properties: {} } }],
+    tool_choice: { type: 'any' },
+    thinking: { type: 'enabled', budget_tokens: 1024 },
+    stream: true,
+    max_tokens: 256,
+    metadata: { source: 'test' },
+    output_config: { effort: 'high' },
+    context_management: { edits: [] }
+  });
+
+  assert.deepEqual(result.supportedFields, ['model', 'messages', 'stream']);
+  assert.deepEqual(result.partialFields, ['system', 'tools', 'tool_choice', 'thinking']);
+  assert.deepEqual(result.ignoredFields, ['max_tokens', 'metadata', 'output_config']);
+  assert.deepEqual(result.futureRiskFields, ['context_management']);
+  assert.match(result.summary, /partial/i);
+  assert.match(result.summary, /ignored/i);
+});
+
+test('buildAnthropicCompatibilityHeaders returns compact warning headers only when needed', () => {
+  assert.equal(typeof compatibility.buildAnthropicCompatibilityHeaders, 'function');
+
+  const headers = compatibility.buildAnthropicCompatibilityHeaders({
+    partialFields: ['system', 'thinking'],
+    ignoredFields: ['max_tokens', 'metadata'],
+    futureRiskFields: ['context_management']
+  });
+
+  assert.deepEqual(headers, {
+    'X-Qwen2API-Anthropic-Compatibility': 'partial=system,thinking;future_risk=context_management',
+    'X-Qwen2API-Anthropic-Warnings': 'ignored=max_tokens,metadata'
+  });
+});
+
+test('buildAnthropicCompatibilityHeaders omits headers when there are no warnings', () => {
+  const headers = compatibility.buildAnthropicCompatibilityHeaders({
+    partialFields: [],
+    ignoredFields: [],
+    futureRiskFields: []
+  });
+
+  assert.deepEqual(headers, {});
+});

--- a/tests/cli-support.test.js
+++ b/tests/cli-support.test.js
@@ -1,0 +1,65 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const cliManager = require('../src/utils/cli.manager.js');
+const cliSupport = require('../src/utils/cli-support.js');
+
+test('pollForToken stops after 3 unsuccessful attempts', async () => {
+  const originalFetch = global.fetch;
+  const originalSetTimeout = global.setTimeout;
+
+  let attempts = 0;
+  global.fetch = async () => {
+    attempts += 1;
+    return {
+      ok: false,
+      status: 504,
+      statusText: 'Gateway Time-out',
+      headers: new Map([['content-type', 'text/html']]),
+      text: async () => '<html>504 Gateway Time-out</html>'
+    };
+  };
+  global.setTimeout = (fn) => {
+    fn();
+    return 0;
+  };
+
+  try {
+    const result = await cliManager.pollForToken('device-code', 'code-verifier');
+    assert.equal(attempts, 3);
+    assert.deepEqual(result, {
+      status: false,
+      access_token: null,
+      refresh_token: null,
+      expiry_date: null
+    });
+  } finally {
+    global.fetch = originalFetch;
+    global.setTimeout = originalSetTimeout;
+  }
+});
+
+test('getAccountCliState marks unsupported CLI accounts with zero quota', () => {
+  const state = cliSupport.getAccountCliState({
+    cli_info: null,
+    cli_unavailable_reason: 'unsupported',
+    expires: Math.floor(Date.now() / 1000) + 24 * 60 * 60,
+    stats: { chat: { input: 0, output: 0 }, cli: { calls: 0, input: 0, output: 0 } }
+  }, {}, Date.now());
+
+  assert.equal(state.status.kind, 'cli_unsupported');
+  assert.equal(state.cliQuotaLimit, 0);
+  assert.equal(state.cliRequestNumber, 0);
+});
+
+test('getAccountCliState keeps normal accounts on default CLI quota', () => {
+  const state = cliSupport.getAccountCliState({
+    cli_info: { request_number: 12 },
+    expires: Math.floor(Date.now() / 1000) + 24 * 60 * 60,
+    stats: { chat: { input: 0, output: 0 }, cli: { calls: 2, input: 10, output: 20 } }
+  }, {}, Date.now());
+
+  assert.equal(state.status.kind, 'active');
+  assert.equal(state.cliQuotaLimit, 2000);
+  assert.equal(state.cliRequestNumber, 12);
+});

--- a/tests/dashboard-cli-unsupported.test.js
+++ b/tests/dashboard-cli-unsupported.test.js
@@ -1,0 +1,13 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const dashboard = fs.readFileSync(require.resolve('../public/src/views/dashboard.vue'), 'utf8');
+
+test('dashboard renders unsupported CLI state as hover-only gray hint', () => {
+  assert.match(dashboard, /v-if="getStatusKind\(token\.email\) === 'cli_unsupported'"/);
+  assert.match(dashboard, /\:title="getStatusTooltip\(token\.email\)"/);
+  assert.match(dashboard, /cliUnavailableShort/);
+  assert.match(dashboard, /text-gray-400/);
+  assert.match(dashboard, /v-if="cliExpanded && getStatusKind\(token\.email\) !== 'cli_unsupported'"/);
+});


### PR DESCRIPTION
## 中文说明
  
  ### 概要
  这个 PR 合并了两个相关commit提交，主要包含两部分改动：
  1. 优化 Anthropic API兼容行为，并补充兼容与说明文档
  2. 优化 CLI 调用失败时的降级策略，避免 free 账号长时间重试，并在面板中明确展示不可用状态

  ---

  ### 变更一：Anthropic 兼容行为优化
  
  这部分改动主要用于增强当前项目对 Anthropic Messages API 的兼容，并让使用者更容易理解哪些字段是：
  
  - 完全支持
  - 部分支持
  - 会被忽略
  - 存在未来兼容风险

  具体包括：

  - 新增兼容性分析逻辑与辅助方法
  - 在 Anthropic 请求处理过程中补充兼容性响应头
  - 补充并更新 README / README-en / README-ru 中的兼容说明与兼容
  - 增加对应测试，覆盖兼容字段分类与响应头生成逻辑

  这部分改动的目标，是让 Anthropic SDK / Claude Code / Anthropic进行更好的兼容。

  ---

  ### 变更二：缩短 CLI 失败重试并展示“不支持 CLI”状态
  
  这部分改动主要针对 free 账号在 CLI 初始化过程中持续失败、但仍会长时间轮询重试的问题。

  在实际验证中，free 账号的 CLI 设备流轮询会连续返回 `504 Gateway Time-out`，旧逻辑会最多重试 60
  次，导致失败反馈过慢，也容易误导用户认为 CLI 仍然可用。

  本次改动包括：
  
  - 将 CLI 设备流轮询次数从 `60` 次缩短为 `3` 次
  - 当 CLI 初始化失败后，将账号标记为 `cli_unsupported`
  - 对于 `cli_unsupported` 账号：
    - 不再继续反复尝试初始化 CLI
    - `/api/accountStats` 会返回 `cliQuotaLimit: 0`
    - 前端面板会显示灰色“不可用”提示
    - 鼠标悬停时可看到 “不支持 CLI 调用” 的提示说明
  - 为该行为新增回归测试，覆盖：
    - 3 次失败后停止轮询
    - unsupported 账号返回 0 CLI 配额
    - dashboard 对 unsupported 状态的灰色 hover 提示展示

  这部分改动的目标，是让 CLI 不可用账号的行为更加明确、反馈更及时，同时减少无意义重试。
  
  ---

  ### 测试情况

  已完成以下验证：
  
  - `node --test tests/*.test.js`
  - 验证 Anthropic 兼容性分析与响应头逻辑
  - 验证 CLI 轮询在失败时仅重试 3 次
  - 验证 free 账号失败后会降级为 `cli_unsupported`
  - 验证 `/api/accountStats` 返回 `cliQuotaLimit: 0`
  - 验证 dashboard 中 unsupported 账号显示灰色提示，并支持 hover 查看说明

  ---

  ## English Description

  ### Summary
  This PR combines two related commits and includes two main changes:

  1. Clarify Anthropic compatibility behavior and add a compatibility matrix/documentation
  2. Improve CLI failure fallback behavior so free accounts stop retrying for too long and are clearly shown as
  unavailable in the dashboard
  
  ---

  ### Change 1: Clarify Anthropic compatibility behavior and documentation
  
  This part improves visibility into the current Anthropic Messages API compatibility surface, making it clearer
  which request fields are:

  - fully supported
  - partially supported
  - ignored
  - potentially risky for future compatibility

  It includes:
  
  - adding compatibility analysis helpers
  - adding compatibility-related response headers in the Anthropic request flow
  - updating README / README-en / README-ru with clearer compatibility notes and matrix
  - adding tests for field classification and compatibility header generation
  
  The goal is to make Anthropic SDK / Claude Code / Anthropic-compatible client integrations more transparent and
  predictable. 

  ---

  ### Change 2: Shorten CLI retries and surface “CLI unsupported” state
  
  This part addresses the case where free accounts fail during CLI initialization but previously kept retrying for
  too long. 

  In real verification, the free account CLI device flow kept returning `504 Gateway Time-out`, while the old logic
  retried up to 60 times. That made failures slow to surface and could mislead users into thinking CLI was still
  available.

  This PR changes that behavior by:
  
  - reducing CLI device-flow polling from `60` attempts to `3`
  - marking accounts as `cli_unsupported` when CLI initialization fails
  - for `cli_unsupported` accounts:
    - stop repeatedly retrying CLI initialization
    - return `cliQuotaLimit: 0` from `/api/accountStats`
    - show a gray “Unavailable” hint in the dashboard
    - show a hover tooltip explaining that CLI calling is not supported
  - adding regression tests for:
    - stopping after 3 failed attempts
    - returning zero CLI quota for unsupported accounts
    - rendering the gray hover-only dashboard hint for unsupported CLI accounts

  The goal is to make unsupported CLI accounts fail faster, behave more explicitly, and avoid unnecessary retry
  loops.    

  ---

  ### Testing
  
  The following verification has been completed:

  - `node --test tests/*.test.js`
  - verified Anthropic compatibility analysis and compatibility headers
  - verified CLI polling stops after 3 failed attempts
  - verified free-account CLI fallback becomes `cli_unsupported`
  - verified `/api/accountStats` returns `cliQuotaLimit: 0`
  - verified the dashboard renders a gray unavailable hint with hover tooltip for unsupported CLI accounts
  
