### PR TITLE
fix: accounts without CLI quota not properly marked in multi-account setup

### DIFF
--- a/public/src/locales/en.json
+++ b/public/src/locales/en.json
@@ -12,11 +12,13 @@
       "cliSuccess": "success",
       "cliToday": "CLI Today",
       "cliUnavailableShort": "Unavailable",
+      "cliPendingShort": "Initializing",
       "status": {
         "active": "active",
         "cooldown": "Cooling down ({until} remaining)",
         "tokenExpiring": "Token is about to expire",
         "cliUnsupported": "CLI calling is not supported",
+        "cliPending": "CLI initializing",
         "unitMin": "point",
         "unitSec": "Second",
         "warn": "There were recent errors ({code}, {ago} ago)",

--- a/public/src/locales/ru.json
+++ b/public/src/locales/ru.json
@@ -66,6 +66,7 @@
       "cliToday": "CLI (сегодня)",
       "calls": "запросов",
       "cliUnavailableShort": "Недоступно",
+      "cliPendingShort": "Инициализация",
       "cliSuccess": "успешно",
       "unitK": "к",
       "unitM": "M",
@@ -76,6 +77,7 @@
         "cooldown": "В охлаждении (осталось {until})",
         "tokenExpiring": "Токен скоро истекает",
         "cliUnsupported": "CLI-вызовы не поддерживаются",
+        "cliPending": "CLI инициализация",
         "unitSec": "сек",
         "unitMin": "мин"
       }

--- a/public/src/locales/zh.json
+++ b/public/src/locales/zh.json
@@ -66,6 +66,7 @@
       "cliToday": "今日 CLI",
       "calls": "次调用",
       "cliUnavailableShort": "不可用",
+      "cliPendingShort": "初始化中",
       "cliSuccess": "成功",
       "unitK": "k",
       "unitM": "M",
@@ -76,6 +77,7 @@
         "cooldown": "冷却中 (剩余 {until})",
         "tokenExpiring": "Token 即将过期",
         "cliUnsupported": "不支持 CLI 调用",
+        "cliPending": "CLI 初始化中",
         "unitSec": "秒",
         "unitMin": "分"
       }

--- a/public/src/views/dashboard.vue
+++ b/public/src/views/dashboard.vue
@@ -236,6 +236,18 @@
                     </span>
                   </div>
                 </template>
+                <template v-else-if="getStatusKind(token.email) === 'cli_pending'">
+                  <div class="flex items-baseline justify-between gap-2 w-full text-left">
+                    <span class="text-blue-400 border-b border-dotted border-blue-300 transition-colors"
+                          :title="getStatusTooltip(token.email)">
+                      {{ t('dash.acct.cliToday') }}:
+                    </span>
+                    <span class="font-medium text-blue-400 text-xs md:text-sm"
+                          :title="getStatusTooltip(token.email)">
+                      {{ t('dash.acct.cliPendingShort') }}
+                    </span>
+                  </div>
+                </template>
                 <button v-else type="button"
                         @click="toggleCliExpanded"
                         class="flex items-baseline justify-between gap-2 w-full text-left focus:outline-none">
@@ -248,7 +260,7 @@
                   </span>
                 </button>
                 <transition name="fade">
-                  <div v-if="cliExpanded && getStatusKind(token.email) !== 'cli_unsupported'" class="space-y-1 pt-1">
+                  <div v-if="cliExpanded && getStatusKind(token.email) !== 'cli_unsupported' && getStatusKind(token.email) !== 'cli_pending'" class="space-y-1 pt-1">
                     <div class="text-xs text-gray-500 text-right">
                       {{ t('dash.acct.cliSuccess') }}: {{ getAccountStats(token.email).cli.calls }}
                     </div>
@@ -643,7 +655,8 @@ const STATUS_EMOJI = Object.freeze({
   warn: '🟡',
   cooldown: '🔴',
   token_expiring: '🪫',
-  cli_unsupported: '⚪'
+  cli_unsupported: '⚪',
+  cli_pending: '🔵'
 })
 const nowTick = ref(Date.now())
 let tickInterval = null
@@ -695,6 +708,9 @@ const getStatusTooltip = (email) => {
   }
   if (kind === 'cli_unsupported') {
     return t('dash.acct.status.cliUnsupported')
+  }
+  if (kind === 'cli_pending') {
+    return t('dash.acct.status.cliPending')
   }
   return t('dash.acct.status.active')
 }

--- a/src/routes/cli.chat.js
+++ b/src/routes/cli.chat.js
@@ -8,17 +8,6 @@ const { DEFAULT_CLI_QUOTA_LIMIT } = require('../utils/cli-support.js')
 router.post('/cli/v1/chat/completions',
     apiKeyVerify,
     async (req, res, next) => {
-        // 异步初始化新账号（不阻塞当前请求）
-        const noCliAccount = accountManager.accountTokens.filter(account => !account.cli_info && account.cli_unavailable_reason !== 'unsupported')
-        if (noCliAccount.length > 0) {
-            const randomNewAccount = noCliAccount[Math.floor(Math.random() * noCliAccount.length)]
-            // 异步初始化，不等待结果
-            accountManager.initializeCliForAccount(randomNewAccount).catch(error => {
-                console.error(`异步初始化CLI账户失败 (${randomNewAccount.email}):`, error)
-            })
-        }
-
-        // 获取当前可用的CLI账户用于本次请求
         const availableAccounts = accountManager.accountTokens.filter(account =>
             account.cli_info && account.cli_info.request_number < DEFAULT_CLI_QUOTA_LIMIT
         )
@@ -29,7 +18,6 @@ router.post('/cli/v1/chat/completions',
             })
         }
 
-        // 随机选择一个可用账户用于本次请求
         const randomAccount = availableAccounts[Math.floor(Math.random() * availableAccounts.length)]
         req.account = randomAccount
         next()

--- a/src/utils/account.js
+++ b/src/utils/account.js
@@ -147,16 +147,15 @@ class Account {
             this.accountRotator.setAccounts(this.accountTokens)
 
             // 初始化 CLI 账户（后台执行，不阻塞 chat-flow init）
-            // CLI poll 在 upstream 504 时可挂 5 分钟（cli.manager.js pollForToken: 60 次 × 5 秒），
-            // 而 chat-flow（/v1/chat/completions, /v1/messages）不需要 cli_info，无需等待。
-            // routes/cli.chat.js:22 已正确过滤无 cli_info 的账户，所以 /cli/* 在 CLI init 未完成时
-            // 自然回退到「无可用账户」状态。
+            // 为所有账户启动 CLI 初始化，确保没有 CLI 额度的账号被正确标记为 unsupported
             if (this.accountTokens.length > 0) {
-                const randomIndex = Math.floor(Math.random() * this.accountTokens.length)
-                const randomAccount = this.accountTokens[randomIndex]
-                logger.info(`后台初始化 CLI 账户, 随机初始化账号: ${randomAccount.email}`, 'ACCOUNT')
-                this._initializeCliAccount(randomAccount).catch(err => {
-                    logger.error(`CLI 账户后台初始化失败: ${randomAccount.email}`, 'ACCOUNT', '', err)
+                logger.info(`后台初始化所有 ${this.accountTokens.length} 个账户的 CLI`, 'ACCOUNT')
+                Promise.allSettled(
+                    this.accountTokens.map(account => this._initializeCliAccount(account))
+                ).then(() => {
+                    const cliReady = this.accountTokens.filter(a => a.cli_info).length
+                    const cliUnsupported = this.accountTokens.filter(a => a.cli_unavailable_reason === 'unsupported').length
+                    logger.success(`CLI 初始化完成: ${cliReady} 个可用, ${cliUnsupported} 个不支持`, 'CLI')
                 })
             }
 
@@ -237,6 +236,8 @@ class Account {
                 logger.error(`CLI账户 ${account.email} 初始化失败：无效的响应数据`, 'CLI', '', cliAccount)
             }
         } catch (error) {
+            account.cli_info = null
+            account.cli_unavailable_reason = 'unsupported'
             logger.error(`CLI账户 ${account.email} 初始化失败`, 'CLI', '', error)
         }
     }
@@ -800,6 +801,11 @@ class Account {
             // 更新轮询器
             this.accountRotator.setAccounts(this.accountTokens)
 
+            // 后台初始化 CLI
+            this._initializeCliAccount(newAccount).catch(err => {
+                logger.error(`新账户 CLI 初始化失败: ${email}`, 'ACCOUNT', '', err)
+            })
+
             logger.success(`成功添加账户: ${email}`, 'ACCOUNT')
             return true
         } catch (error) {
@@ -850,6 +856,11 @@ class Account {
 
             // 更新轮询器
             this.accountRotator.setAccounts(this.accountTokens)
+
+            // 后台初始化 CLI
+            this._initializeCliAccount(newAccount).catch(err => {
+                logger.error(`新账户 CLI 初始化失败: ${email}`, 'ACCOUNT', '', err)
+            })
 
             logger.success(`成功添加账户: ${email}`, 'ACCOUNT')
             return true

--- a/src/utils/cli-support.js
+++ b/src/utils/cli-support.js
@@ -12,6 +12,8 @@ function getAccountCliState(account, rotatorRecord = {}, now = Date.now()) {
   let kind = 'active'
   if (cliUnavailableReason === 'unsupported') {
     kind = 'cli_unsupported'
+  } else if (!account.cli_info && !cliUnavailableReason) {
+    kind = 'cli_pending'
   } else if (cooldownEndsAt && now < cooldownEndsAt) {
     kind = 'cooldown'
   } else if (lastErrorAt && (now - lastErrorAt) < WARN_WINDOW_MS) {

--- a/tests/cli-support.test.js
+++ b/tests/cli-support.test.js
@@ -63,3 +63,16 @@ test('getAccountCliState keeps normal accounts on default CLI quota', () => {
   assert.equal(state.cliQuotaLimit, 2000);
   assert.equal(state.cliRequestNumber, 12);
 });
+
+test('getAccountCliState marks uninitialized accounts as cli_pending', () => {
+  const state = cliSupport.getAccountCliState({
+    cli_info: null,
+    cli_unavailable_reason: null,
+    expires: Math.floor(Date.now() / 1000) + 24 * 60 * 60,
+    stats: { chat: { input: 0, output: 0 }, cli: { calls: 0, input: 0, output: 0 } }
+  }, {}, Date.now());
+
+  assert.equal(state.status.kind, 'cli_pending');
+  assert.equal(state.cliQuotaLimit, 2000);
+  assert.equal(state.cliRequestNumber, 0);
+});

--- a/tests/dashboard-cli-unsupported.test.js
+++ b/tests/dashboard-cli-unsupported.test.js
@@ -9,5 +9,11 @@ test('dashboard renders unsupported CLI state as hover-only gray hint', () => {
   assert.match(dashboard, /\:title="getStatusTooltip\(token\.email\)"/);
   assert.match(dashboard, /cliUnavailableShort/);
   assert.match(dashboard, /text-gray-400/);
-  assert.match(dashboard, /v-if="cliExpanded && getStatusKind\(token\.email\) !== 'cli_unsupported'"/);
+  assert.match(dashboard, /v-if="cliExpanded && getStatusKind\(token\.email\) !== 'cli_unsupported' && getStatusKind\(token\.email\) !== 'cli_pending'"/);
+});
+
+test('dashboard renders pending CLI state as blue hint', () => {
+  assert.match(dashboard, /v-else-if="getStatusKind\(token\.email\) === 'cli_pending'"/);
+  assert.match(dashboard, /cliPendingShort/);
+  assert.match(dashboard, /text-blue-400/);
 });


### PR DESCRIPTION
Description

  Problem

  In multi-account scenarios, only 1 random account was CLI-initialized at startup. The remaining accounts were never
  initialized, causing:
  - WebUI showed them as "active" but they couldn't serve CLI requests
  - Accounts without CLI quota were never marked as unsupported
  - CLI endpoint kept returning "no available CLI accounts"
  
  Root Cause

  account.js startup logic only called _initializeCliAccount() once for a random account. If that account happened to have no
  CLI quota, all CLI requests would fail, while other accounts with valid quota were never attempted.

  Fix
  
  - Use Promise.allSettled at startup to initialize CLI for all accounts in parallel, ensuring accounts without quota are
  properly marked as unsupported
  - Add unsupported marking in _initializeCliAccount catch block to prevent accounts from getting stuck in an unmarked state on
  exception
  - addAccount / addAccountWithToken now automatically trigger CLI initialization for new accounts
  - Remove ineffective lazy-init logic from cli.chat middleware (all accounts are already initialized at startup)
  - Add cli_pending status with 🔵 indicator in WebUI for accounts still initializing
  - Update zh/en/ru translations


问题

  在多账号场景下，启动时只随机选择 1 个账号进行 CLI 初始化。其余账号从未被初始化，导致：
  - WebUI 上显示为"活跃"，但实际无法服务 CLI 请求
  - 没有 CLI 额度的账号不会被标记为 unsupported
  - CLI 端点持续返回"没有可用的CLI账户"

  根因

  account.js 启动逻辑只调用了一次 _initializeCliAccount()，选中的账号如果恰好没有 CLI 额度，所有 CLI
  请求都会失败，而其他有额度的账号从未被尝试。

  修复

  - 启动时使用 Promise.allSettled 并行初始化所有账号的 CLI，确保没有额度的账号被正确标记为 unsupported
  - _initializeCliAccount 的 catch 块增加 unsupported 标记，防止异常时账号卡在未标记状态
  - addAccount / addAccountWithToken 添加账号后自动触发 CLI 初始化
  - 移除 cli.chat 中间件中无效的懒初始化逻辑（启动时已全部初始化，无需再尝试）
  - 新增 cli_pending 状态，WebUI 上用 🔵 指示正在初始化的账号
  - 更新中/英/俄三语翻译
