### PR TITLE
增加工具前缀，避免与qwen内部工具重名

### DIFF
--- a/src/utils/tool-prompt.js
+++ b/src/utils/tool-prompt.js
@@ -53,6 +53,8 @@ const compressSchemaType = (schema) => {
   return type || 'any';
 };
 
+const TOOL_PREFIX = 'My_';
+
 /**
  * 将单个工具定义压缩为 TS 风格签名
  * @param {Object} tool - OpenAI 工具定义
@@ -60,7 +62,8 @@ const compressSchemaType = (schema) => {
  */
 const compressToolDefinition = (tool) => {
   const fn = tool?.function || tool;
-  const name = fn?.name || 'unknown';
+  // 增加工具前缀，例如Write等工具会被千问保留，不让调用
+  const name = fn.name ? TOOL_PREFIX + fn.name : 'unknown';
   const description = (fn?.description || '').trim();
   const params = fn?.parameters || { type: 'object', properties: {} };
   const signature = compressSchemaType(params);
@@ -212,11 +215,14 @@ const parseToolCallPayload = (raw) => {
 
   try {
     const parsed = JSON.parse(text);
+
     if (!parsed || typeof parsed !== 'object') return null;
-    const name = parsed.name || parsed.tool || parsed.function;
+    let name = parsed.name || parsed.tool || parsed.function;
     const args = parsed.arguments ?? parsed.parameters ?? parsed.args ?? {};
     if (!name) return null;
-    return { name: String(name), arguments: args };
+    // 去掉工具前缀
+    name = name.replace(TOOL_PREFIX, '');
+    return { name, arguments: args };
   } catch (error) {
     logger.warning?.('解析 tool_call 负载失败', 'TOOL', text, error?.message);
     return null;


### PR DESCRIPTION
我在使用claude code的时候发现，Write等工具无法识别：

<img width="1704" height="555" alt="image" src="https://github.com/user-attachments/assets/12270a5e-21b4-4ada-a6fe-15020cecd71d" />

应该是qwen把这个工具当作内部工具了，为了避免与qwen内部工具重名，在发送工具的时候增加前缀，收到工具消息后再去掉前缀。

<img width="810" height="220" alt="image" src="https://github.com/user-attachments/assets/351253e7-79bc-427c-8b0f-032cbf456dea" />

测试已经成功。

PS：我尝试了增加`_`这样的短前缀依然被ai自动去掉，改成3个字母以上就比较稳妥。
