### PR TITLE
fix(login): pass account.proxy into tokenManager.login on add/batch flows

### DIFF
--- a/src/routes/accounts.js
+++ b/src/routes/accounts.js
@@ -188,7 +188,7 @@ const processBatchAccountItem = async (task, account) => {
   updateBatchTaskMessage(task)
 
   try {
-    const authToken = await accountManager.login(email, password)
+    const authToken = await accountManager.login(email, password, proxy)
     if (!authToken) {
       throw new Error('登录失败')
     }
@@ -340,7 +340,7 @@ router.post('/setAccount', adminKeyVerify, async (req, res) => {
       return res.status(409).json({ error: '账号已存在' })
     }
 
-    const authToken = await accountManager.login(email, password)
+    const authToken = await accountManager.login(email, password, normalizedProxy)
     if (!authToken) {
       return res.status(401).json({ error: '登录失败' })
     }

--- a/src/utils/account.js
+++ b/src/utils/account.js
@@ -658,8 +658,9 @@ class Account {
      * @param {string} password - 密码
      * @returns {Promise<string|null>} 令牌或null
      */
-    async login(email, password) {
-        return await this.tokenManager.login(email, password)
+    async login(email, password, proxy) {
+        const accountLike = proxy ? { proxy } : undefined
+        return await this.tokenManager.login(email, password, accountLike)
     }
 
     /**
@@ -763,7 +764,7 @@ class Account {
             }
 
             // 尝试登录获取令牌
-            const token = await this.tokenManager.login(email, password)
+            const token = await this.tokenManager.login(email, password, proxy ? { proxy } : undefined)
             if (!token) {
                 logger.error(`账户 ${email} 登录失败，无法添加`, 'ACCOUNT')
                 return false


### PR DESCRIPTION
## Summary

`addAccount`, `/api/setAccount` and the batch processor call `tokenManager.login(email, password)` without the third `account` parameter. As a result, `getProxyAgent` falls back to the global `PROXY_URL` (often empty), and the very first login of every newly added account goes through the host's direct IP instead of the per-account proxy configured by the user.

When several accounts are batch-added from one host, upstream sees *one IP authenticated N different accounts* — a classic anti-bot trigger that can lead to all of them sharing the same WAF mark.

`refreshToken` already passes `account` correctly, so token refresh after the initial add does honor `account.proxy`. **This bug only affects the very first login.**

## Change

- `accountManager.login(email, password, proxy?)` — accepts an optional `proxy` and forwards it as a minimal account-like object to `tokenManager.login`.
- `addAccount(email, password, proxy)` — passes its own `proxy` argument through.
- `/api/setAccount` route — passes `normalizedProxy` from the request body.
- batch processor `processBatchAccountItem` — passes the `proxy` it already destructured.

No behavior change for callers that don't supply a proxy.

## Test plan

- [x] Single-account add via `/api/setAccount` with `proxy` body field — verify outgoing login egress IP is the proxy, not the host
- [x] Batch add with `proxy` per row
- [x] Re-add without `proxy` — still goes through global `PROXY_URL` / direct as before
- [x] `forceRefreshAllAccounts` — unchanged (already worked correctly via `refreshToken`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)