### PR TITLE
安全: getAllAccounts 不再明文返回账号令牌 (JWT)

### DIFF
--- a/public/src/views/dashboard.vue
+++ b/public/src/views/dashboard.vue
@@ -196,7 +196,7 @@
                     <span class="text-gray-700 min-w-[96px] text-left font-semibold">🔐 Token:</span>
                     <span class="font-medium whitespace-nowrap text-left text-sm">{{ token.token }}</span>
                   </div>
-                  <button @click="copyToClipboard(token.token)" class="absolute right-2 opacity-0 hover:opacity-100 transition-opacity bg-blue-200 hover:bg-blue-300 rounded px-2 py-1 text-base">📋</button>
+                  <!-- token 已由后端掩码，复制按钮无意义，故移除 -->
                 </div>
                 <div class="relative flex items-center bg-blue-50/80 rounded-lg px-2 py-1">
                   <div class="overflow-x-auto scrollbar-hide flex-1 flex items-center space-x-2">

--- a/src/routes/accounts.js
+++ b/src/routes/accounts.js
@@ -266,9 +266,22 @@ const runBatchAccountTask = async (task, newAccounts) => {
   }
 }
 
+// 账号令牌（JWT）掩码占位符
+const ACCOUNT_TOKEN_MASK = '••••••••'
+
+/**
+ * 掩码账号令牌，避免 getAllAccounts 明文返回 JWT。
+ * JWT 相当于登录该 Qwen 账号的凭证，一旦管理密钥泄露即可被批量窃取。
+ * 令牌不会被前端回传（新增账号用 email+password 重新登录，编辑代理/刷新仅用 email），
+ * 故掩码不会破坏任何回写流程；账号仍可通过 email 区分，刷新是否成功可由 expires 变化判断。
+ * @param {string|null|undefined} token 原始 JWT
+ * @returns {string} 存在令牌时返回掩码占位符，否则返回空串
+ */
+const maskAccountToken = (token) => (token ? ACCOUNT_TOKEN_MASK : '')
+
 /**
  * 获取所有账号（分页）
- * 
+ *
  * @param {number} page 页码
  * @param {number} pageSize 每页数量
  * @returns {Object} 账号列表
@@ -291,7 +304,7 @@ router.get('/getAllAccounts', adminKeyVerify, async (req, res) => {
       return {
         email: account.email,
         password: account.password,
-        token: account.token,
+        token: maskAccountToken(account.token),
         expires: account.expires,
         proxy: account.proxy ?? null
       }


### PR DESCRIPTION
## 问题

`GET /api/getAllAccounts`（仅 `adminKeyVerify` 可访问）对每个账号明文返回 JWT 令牌（`token` 字段）。该 JWT 相当于登录对应 Qwen 账号的凭证：一旦管理密钥泄露或被弱口令猜中，攻击者只需一次请求即可批量导出所有账号令牌，用于冒充账号、横向渗透。

管理密钥与普通 API 密钥的拆分已经完成（`adminKey = keys[0]`），但被保护的响应体本身仍在明文承载凭证——即“泄露一个管理密钥 = 泄露全部账号令牌”。本 PR 收敛这一爆炸半径。

## 改动

- **后端** `src/routes/accounts.js`：新增 `maskAccountToken()`，`getAllAccounts` 返回掩码占位符（`••••••••`）而非明文 JWT。
  - 令牌**不会被前端回传**：新增账号用 `email`+`password` 重新登录，编辑代理 / 刷新令牌仅凭 `email`。因此掩码**不破坏任何回写流程**。
  - 账号仍可由 `email` 区分；刷新是否成功可由 `expires` 变化判断。
- **前端** `public/src/views/dashboard.vue`：移除 token 的复制按钮（掩码后复制无意义）。

## 范围与向后兼容

- 仅掩码 `token`。`password` 与 `proxy` 仍按原样返回，以保留账号导出（`email:password` 备份）与账号级代理编辑（表单回填）功能，避免破坏现有交互；如需进一步收敛可另行处理。
- 响应结构不变（`token` 仍为字符串字段），不影响其它调用方。

<details>
<summary>Русская версия</summary>

## Проблема

`GET /api/getAllAccounts` (доступен только по админ-ключу, `adminKeyVerify`) отдаёт для каждого аккаунта токен JWT (поле `token`) открытым текстом. Этот токен по сути равнозначен входу в соответствующий аккаунт Qwen: если админ-ключ утечёт или будет подобран, атакующему хватит одного запроса, чтобы разом выгрузить токены всех аккаунтов и выдавать себя за них.

Разделение админ-ключа и обычного ключа API уже сделано (`adminKey = keys[0]`), но сам ответ, который этим ключом защищён, по-прежнему несёт учётные данные открытым текстом — то есть «утечка одного админ-ключа = утечка всех токенов». Этот PR сокращает ущерб от такой утечки.

## Изменения

- **Серверная часть** `src/routes/accounts.js`: добавлена функция `maskAccountToken()`; `getAllAccounts` возвращает маску-заглушку (`••••••••`) вместо настоящего JWT.
  - Токен **никогда не отправляется обратно с интерфейса**: добавление аккаунта заново выполняет вход по `email`+`password`, а редактирование прокси / обновление токена используют только `email`. Поэтому маскировка **не ломает ни один путь записи**.
  - Аккаунты по-прежнему различаются по `email`; успешное обновление токена видно по изменившейся дате `expires`.
- **Интерфейс** `public/src/views/dashboard.vue`: убрана кнопка копирования токена (копировать маску незачем).

## Область и обратная совместимость

- Маскируется только `token`. Поля `password` и `proxy` возвращаются как есть, чтобы сохранить экспорт аккаунтов (резервная копия `email:password`) и редактирование прокси у аккаунта (подстановка в форму); дальнейшее усиление можно вынести отдельно.
- Структура ответа не меняется (`token` остаётся строковым полем), другие потребители не затронуты.

</details>
