### PR TITLE
feat(models): 模型列表缓存支持 TTL 过期自动刷新（MODELS_CACHE_TTL）

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -101,6 +101,7 @@ SEARCH_INFO_MODE=table        # Search info display mode (table/text)
 OUTPUT_THINK=true             # Whether to output thinking process (true/false)
 LEGACY_REASONING_IN_CONTENT=false # Reasoning format, false=reasoning_content field, true=legacy <think> inside content (true/false)
 SIMPLE_MODEL_MAP=false        # Simplify model mapping (true/false)
+MODELS_CACHE_TTL=3600         # Model list cache TTL in seconds, 0=never expires
 
 # 🌐 Proxy and Reverse Proxy Configuration
 QWEN_CHAT_PROXY_URL=          # Custom Chat API reverse proxy URL (default: https://chat.qwen.ai)
@@ -129,6 +130,7 @@ CACHE_MODE=default            # Image cache mode (default/file)
 | `OUTPUT_THINK` | Whether to show AI thinking process | `true` or `false` |
 | `LEGACY_REASONING_IN_CONTENT` | Reasoning output format. Default `false` = reasoning goes to a separate `reasoning_content` field; `true` = legacy behavior (`<think>` inside `content`) | `true` or `false` |
 | `SIMPLE_MODEL_MAP` | Simplify model mapping, return basic models without variants only | `true` or `false` |
+| `MODELS_CACHE_TTL` | Model list cache TTL in seconds; after expiry the next request refreshes it from upstream; `0` = never expires | `3600` |
 | `QWEN_CHAT_PROXY_URL` | Custom Chat API reverse proxy address | `https://your-proxy.com` |
 | `QWEN_CLI_PROXY_URL` | Custom CLI API reverse proxy address | `https://your-cli-proxy.com` |
 | `PROXY_URL` | Outbound request proxy address, supports HTTP/HTTPS/SOCKS5 | `http://127.0.0.1:7890` |

--- a/README-ru.md
+++ b/README-ru.md
@@ -121,6 +121,7 @@ SEARCH_INFO_MODE=table        # Режим отображения результ
 OUTPUT_THINK=true             # Выводить ли процесс размышления (true/false)
 LEGACY_REASONING_IN_CONTENT=false # Формат рассуждений: false=поле reasoning_content, true=старый режим <think> внутри content (true/false)
 SIMPLE_MODEL_MAP=false        # Упрощенное сопоставление моделей (true/false)
+MODELS_CACHE_TTL=3600         # Срок жизни кэша списка моделей (сек), 0=бессрочно
 
 # 🌐 Прокси и обратный прокси
 QWEN_CHAT_PROXY_URL=          # Пользовательский URL обратного прокси Chat API (по умолчанию: https://chat.qwen.ai)
@@ -149,6 +150,7 @@ CACHE_MODE=default            # Режим кэширования изображ
 | `OUTPUT_THINK` | Отображать ли процесс размышления AI | `true` или `false` |
 | `LEGACY_REASONING_IN_CONTENT` | Формат вывода рассуждений. По умолчанию `false` = рассуждения в отдельном поле `reasoning_content`; `true` = старый режим (`<think>` внутри `content`) | `true` или `false` |
 | `SIMPLE_MODEL_MAP` | Упрощенное сопоставление моделей, возвращает только базовые модели без вариантов | `true` или `false` |
+| `MODELS_CACHE_TTL` | Срок жизни кэша списка моделей (в секундах); по истечении следующий запрос обновит список; `0` = бессрочный кэш | `3600` |
 | `QWEN_CHAT_PROXY_URL` | Пользовательский адрес обратного прокси Chat API | `https://your-proxy.com` |
 | `QWEN_CLI_PROXY_URL` | Пользовательский адрес обратного прокси CLI API | `https://your-cli-proxy.com` |
 | `PROXY_URL` | Адрес прокси для исходящих запросов, поддержка HTTP/HTTPS/SOCKS5 | `http://127.0.0.1:7890` |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ SEARCH_INFO_MODE=table        # 搜索信息展示模式 (table/text)
 OUTPUT_THINK=true             # 是否输出思考过程 (true/false)
 LEGACY_REASONING_IN_CONTENT=false # 推理输出格式，false=reasoning_content字段，true=旧版<think>并入content (true/false)
 SIMPLE_MODEL_MAP=false        # 简化模型映射 (true/false)
+MODELS_CACHE_TTL=3600         # 模型列表缓存有效期（秒），0=永不过期
 
 # 🌐 代理与反代配置
 QWEN_CHAT_PROXY_URL=          # 自定义 Chat API 反代URL (默认: https://chat.qwen.ai)
@@ -129,6 +130,7 @@ CACHE_MODE=default            # 图片缓存模式 (default/file)
 | `OUTPUT_THINK` | 是否显示 AI 思考过程 | `true` 或 `false` |
 | `LEGACY_REASONING_IN_CONTENT` | 推理输出格式。默认 `false`=推理走独立的 `reasoning_content` 字段；`true`=旧版行为（`<think>` 并入 `content`） | `true` 或 `false` |
 | `SIMPLE_MODEL_MAP` | 简化模型映射，只返回基础模型不包含变体 | `true` 或 `false` |
+| `MODELS_CACHE_TTL` | 模型列表缓存有效期（秒），过期后下次请求自动向上游刷新；`0` 表示永不过期 | `3600` |
 | `QWEN_CHAT_PROXY_URL` | 自定义 Chat API 反代地址 | `https://your-proxy.com` |
 | `QWEN_CLI_PROXY_URL` | 自定义 CLI API 反代地址 | `https://your-cli-proxy.com` |
 | `PROXY_URL` | 出站请求代理地址，支持 HTTP/HTTPS/SOCKS5 | `http://127.0.0.1:7890` |

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -26,6 +26,8 @@ const config = {
     adminKey: adminKey,
     batchLoginConcurrency: Math.max(1, parseInt(process.env.BATCH_LOGIN_CONCURRENCY) || 5),
     simpleModelMap: process.env.SIMPLE_MODEL_MAP === 'true' ? true : false,
+    // 模型列表缓存有效期（秒），过期后下次请求自动刷新；0 = 永不过期（旧版行为）
+    modelsCacheTtl: process.env.MODELS_CACHE_TTL !== undefined ? Math.max(0, parseInt(process.env.MODELS_CACHE_TTL, 10) || 0) : 3600,
     listenAddress: process.env.LISTEN_ADDRESS || null,
     listenPort: process.env.SERVICE_PORT || 3000,
     searchInfoMode: process.env.SEARCH_INFO_MODE === 'table' ? "table" : "text",

--- a/src/models/models-map.js
+++ b/src/models/models-map.js
@@ -4,13 +4,20 @@ const { getSsxmodItna, getSsxmodItna2 } = require('../utils/ssxmod-manager')
 const { getProxyAgent, getChatBaseUrl, applyProxyToAxiosConfig } = require('../utils/proxy-helper')
 const { generateUUID } = require('../utils/tools.js')
 const { logger } = require('../utils/logger')
+const config = require('../config/index.js')
 
 let cachedModels = null
+let cachedModelsAt = 0
 let fetchPromise = null
 
+// 缓存是否已过期（modelsCacheTtl = 0 表示永不过期）
+const isCacheExpired = () => {
+    return config.modelsCacheTtl > 0 && Date.now() - cachedModelsAt > config.modelsCacheTtl * 1000
+}
+
 const getLatestModels = async (force = false) => {
-    // 如果有缓存且不强制刷新，直接返回
-    if (cachedModels && !force) {
+    // 如果有缓存、未过期且不强制刷新，直接返回
+    if (cachedModels && !force && !isCacheExpired()) {
         return cachedModels
     }
 
@@ -62,11 +69,17 @@ const getLatestModels = async (force = false) => {
 
     fetchPromise = axios.get(`${chatBaseUrl}/api/models`, requestConfig).then(response => {
         cachedModels = response.data.data
+        cachedModelsAt = Date.now()
         fetchPromise = null
         return cachedModels
     }).catch(error => {
         logger.error(`获取模型列表失败: ${error.message}`, 'MODEL')
         fetchPromise = null
+        // 刷新失败时回退到旧缓存，避免返回空列表；重置时间戳以免每个请求都重试
+        if (cachedModels) {
+            cachedModelsAt = Date.now()
+            return cachedModels
+        }
         return []
     })
 


### PR DESCRIPTION
**问题**

模型列表只在首次请求时从 `chat.qwen.ai/api/models` 拉取并永久缓存，新模型上线后必须重启服务才能出现在 `/v1/models`。

**改动**

- 新增环境变量 `MODELS_CACHE_TTL`（秒），默认 `3600`；设为 `0` 保持旧行为（永不过期）
- 缓存过期后，下次请求自动向上游刷新
- 刷新失败时回退旧缓存并重置计时（避免故障期间每个请求都重试），不再返回空列表
- README（中/英/俄）补充变量说明

**测试**

用桩模块验证：首次拉取、TTL 内走缓存、过期自动刷新、失败回退旧缓存、`force=true` 立即刷新 — 均通过；`node --check` 通过。

Fixes #143

<details>
<summary>Русский перевод / Russian translation</summary>

**Проблема**

Список моделей запрашивается у `chat.qwen.ai/api/models` один раз при первом обращении и кэшируется навсегда — новая модель появляется в `/v1/models` только после перезапуска сервиса.

**Изменения**

- Новая переменная окружения `MODELS_CACHE_TTL` (секунды), по умолчанию `3600`; `0` — прежнее поведение (бессрочный кэш)
- По истечении срока следующий запрос автоматически обновляет список
- При сбое обновления — возврат старого кэша со сдвигом таймера (без повтора на каждый запрос во время сбоя), пустой список больше не отдаётся
- Переменная задокументирована в README (кит./англ./рус.)

**Проверка**

Скрипт с подставными модулями: первый запрос тянет список, в пределах срока — кэш, по истечении — автообновление, при сбое — старый кэш, `force=true` обновляет немедленно. Все проверки прошли; `node --check` без ошибок.

</details>
