### PR TITLE
fix(agent): prevent premature stops in streaming tool loops

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "node src/start.js",
     "dev": "nodemon src/server.js",
+    "test": "node --test tests/*.test.js",
     "pm2": "pm2 start ecosystem.config.js",
     "pm2:stop": "pm2 stop qwen2api",
     "pm2:restart": "pm2 restart qwen2api",

--- a/src/controllers/anthropic.js
+++ b/src/controllers/anthropic.js
@@ -7,13 +7,33 @@ const {
   buildToolSystemPrompt,
   foldToolMessages,
   parseToolCallsFromText,
-  createToolCallStreamParser
+  createToolCallStreamParser,
+  createNativeToolCallAccumulator
 } = require('../utils/tool-prompt.js');
+const { consumeSSEStream } = require('../utils/sse.js');
 const { logger } = require('../utils/logger');
 const {
   analyzeAnthropicCompatibility,
   buildAnthropicCompatibilityHeaders
 } = require('./anthropic.compatibility.js');
+
+const mapAnthropicStopReason = (upstreamReason, hasToolCalls, sawDone) => {
+  if (hasToolCalls) return 'tool_use';
+  if (upstreamReason === 'length' || upstreamReason === 'max_tokens') return 'max_tokens';
+  if (upstreamReason === 'stop_sequence') return 'stop_sequence';
+  if (upstreamReason === 'content_filter' || upstreamReason === 'refusal') return 'refusal';
+  if (upstreamReason === 'stop' || upstreamReason === 'end_turn') return 'end_turn';
+  if (!upstreamReason && sawDone) return 'end_turn';
+  return null;
+};
+
+const writeAnthropicError = (res, message, errorType = 'api_error') => {
+  writeAnthropicEvent(res, 'error', {
+    type: 'error',
+    error: { type: errorType, message }
+  });
+  res.end();
+};
 
 /**
  * 安全累计 chat stats（与 chat.js attributeChatUsage 共享语义）
@@ -137,8 +157,14 @@ const flattenAnthropicMessages = (messages) => {
 
     // user 角色：tool_result 拆为独立 role=tool 消息，普通文本/图片合并保留
     const collectedTextParts = [];
+    const flushCollectedText = () => {
+      if (collectedTextParts.length === 0) return;
+      out.push({ role: 'user', content: collectedTextParts.join('') });
+      collectedTextParts.length = 0;
+    };
     for (const block of msg.content) {
       if (block?.type === 'tool_result') {
+        flushCollectedText();
         const resultContent = typeof block.content === 'string'
           ? block.content
           : Array.isArray(block.content)
@@ -173,9 +199,7 @@ const flattenAnthropicMessages = (messages) => {
         }
       }
     }
-    if (collectedTextParts.length > 0) {
-      out.push({ role: 'user', content: collectedTextParts.join('') });
-    }
+    flushCollectedText();
   }
 
   return out;
@@ -184,7 +208,7 @@ const flattenAnthropicMessages = (messages) => {
 /**
  * 构造内部 Qwen 上游请求体
  * @param {Object} anthropicReq - Anthropic 风格请求体
- * @returns {Promise<{body: Object, hasTools: boolean, toolChoice: any, enable_thinking: boolean, model: string}>} 转换结果
+ * @returns {Promise<{body: Object, hasTools: boolean, toolChoice: any, allowedToolNames: string[], enable_thinking: boolean, model: string}>} 转换结果
  */
 const buildInternalRequest = async (anthropicReq) => {
   const { model, messages, system, tools, tool_choice, stream, thinking } = anthropicReq;
@@ -250,6 +274,7 @@ const buildInternalRequest = async (anthropicReq) => {
     body,
     hasTools,
     toolChoice: internalToolChoice,
+    allowedToolNames: normalizedTools.map(tool => tool.function.name).filter(Boolean),
     enable_thinking: thinkingCfg.thinking_enabled,
     model: parsedModel
   };
@@ -261,13 +286,27 @@ const buildInternalRequest = async (anthropicReq) => {
  * @param {string} hint - 重试提示词
  * @returns {Object} 新请求体
  */
-const appendRetryHint = (body, hint) => ({
-  ...body,
-  messages: [
-    ...(Array.isArray(body.messages) ? body.messages : []),
-    { role: 'system', content: hint }
-  ]
-});
+const appendRetryHint = (body, hint) => {
+  const messages = Array.isArray(body.messages)
+    ? body.messages.map(message => ({ ...message }))
+    : [];
+  if (messages.length === 0) {
+    messages.push({ role: 'user', content: hint });
+  } else {
+    const last = messages[messages.length - 1];
+    if (typeof last.content === 'string') {
+      last.content = `${last.content}\n\n# Tool-call retry\n${hint}`;
+    } else if (Array.isArray(last.content)) {
+      const textPart = last.content.find(part => part?.type === 'text');
+      if (textPart) {
+        textPart.text = `${textPart.text || ''}\n\n# Tool-call retry\n${hint}`;
+      } else {
+        last.content = [{ type: 'text', text: hint }, ...last.content];
+      }
+    }
+  }
+  return { ...body, messages };
+};
 
 /**
  * 判断 tool_choice 是否需要强制调用
@@ -298,36 +337,11 @@ const buildRetryHint = (toolChoice) => {
  * @param {(json: Object) => Promise<void>|void} onDelta - 单个 delta 回调
  * @returns {Promise<void>} 完成 Promise
  */
-const consumeUpstream = (upstream, onDelta) => new Promise((resolve, reject) => {
-  const decoder = new TextDecoder('utf-8');
-  let buffer = '';
-
-  upstream.on('data', async (chunk) => {
-    buffer += decoder.decode(chunk, { stream: true });
-    const segments = [];
-    let startIndex = 0;
-    while (true) {
-      const dataStart = buffer.indexOf('data: ', startIndex);
-      if (dataStart === -1) break;
-      const dataEnd = buffer.indexOf('\n\n', dataStart);
-      if (dataEnd === -1) break;
-      segments.push(buffer.substring(dataStart, dataEnd).trim());
-      startIndex = dataEnd + 2;
-    }
-    if (startIndex > 0) buffer = buffer.substring(startIndex);
-
-    for (const seg of segments) {
-      const payload = seg.replace('data: ', '');
-      if (!isJson(payload)) continue;
-      try {
-        await onDelta(JSON.parse(payload));
-      } catch (e) {
-        logger.error('Anthropic 上游处理错误', 'ANTHROPIC', '', e);
-      }
-    }
-  });
-  upstream.on('end', () => resolve());
-  upstream.on('error', err => reject(err));
+const consumeUpstream = async (upstream, onDelta) => consumeSSEStream(upstream, async (frame) => {
+  const payload = frame.data;
+  if (!payload || payload.trim() === '[DONE]') return;
+  if (!isJson(payload)) return;
+  await onDelta(JSON.parse(payload));
 });
 
 /**
@@ -367,7 +381,7 @@ const writeAnthropicEvent = (res, event, data) => {
  * @returns {Promise<void>} 完成 Promise
  */
 const handleAnthropicStream = async (res, ctx, upstream) => {
-  const { message_id, model, hasTools, toolChoice, requestBody } = ctx;
+  const { message_id, model, hasTools, toolChoice, requestBody, allowedToolNames = [] } = ctx;
 
   res.set({
     'Content-Type': 'text/event-stream',
@@ -393,10 +407,17 @@ const handleAnthropicStream = async (res, ctx, upstream) => {
   let blockIndex = -1;
   let textBlockOpen = false;
   let thinkingBlockOpen = false;
+  let thinkingSignature = null;
   let promptTokens = 0;
   let completionTokens = 0;
+  let upstreamFinishReason = null;
+  let upstreamSawDone = false;
+  let upstreamEventCount = 0;
 
-  const parser = hasTools ? createToolCallStreamParser() : null;
+  const parser = hasTools ? createToolCallStreamParser({ allowedToolNames }) : null;
+  const nativeToolAccumulator = hasTools
+    ? createNativeToolCallAccumulator({ allowedToolNames })
+    : null;
 
   /**
    * 关闭当前打开的文本块
@@ -413,8 +434,14 @@ const handleAnthropicStream = async (res, ctx, upstream) => {
    */
   const closeThinkingBlockIfOpen = () => {
     if (thinkingBlockOpen) {
+      writeAnthropicEvent(res, 'content_block_delta', {
+        type: 'content_block_delta',
+        index: blockIndex,
+        delta: { type: 'signature_delta', signature: thinkingSignature }
+      });
       writeAnthropicEvent(res, 'content_block_stop', { type: 'content_block_stop', index: blockIndex });
       thinkingBlockOpen = false;
+      thinkingSignature = null;
     }
   };
 
@@ -427,6 +454,7 @@ const handleAnthropicStream = async (res, ctx, upstream) => {
     if (!thinkingBlockOpen) {
       closeTextBlockIfOpen();
       blockIndex += 1;
+      thinkingSignature = `qwen2api_${generateUUID().replace(/-/g, '')}`;
       writeAnthropicEvent(res, 'content_block_start', {
         type: 'content_block_start',
         index: blockIndex,
@@ -498,12 +526,22 @@ const handleAnthropicStream = async (res, ctx, upstream) => {
    * @param {Object} json - 上游 SSE delta
    */
   const onUpstreamDelta = async (json) => {
-    if (!json.choices || json.choices.length === 0) return;
     if (json.usage) {
       promptTokens = json.usage.prompt_tokens || promptTokens;
       completionTokens = json.usage.completion_tokens || completionTokens;
     }
-    const delta = json.choices[0].delta;
+    if (!json.choices || json.choices.length === 0) return;
+    const choice = json.choices[0];
+    const reportedFinishReason = choice.finish_reason ?? choice.delta?.finish_reason;
+    if (reportedFinishReason !== undefined && reportedFinishReason !== null) {
+      upstreamFinishReason = reportedFinishReason;
+    }
+    const delta = choice.delta || {};
+    if (nativeToolAccumulator && Array.isArray(delta.tool_calls)) {
+      nativeToolAccumulator.push(delta.tool_calls);
+    } else if (nativeToolAccumulator && delta.function_call) {
+      nativeToolAccumulator.push([{ index: 0, type: 'function', function: delta.function_call }]);
+    }
     if (delta && delta.name === 'web_search') {
       webSearchInfo = delta.extra?.web_search_info;
     }
@@ -536,16 +574,26 @@ const handleAnthropicStream = async (res, ctx, upstream) => {
     }
   };
 
-  await consumeUpstream(upstream, onUpstreamDelta);
+  const initialStreamResult = await consumeUpstream(upstream, onUpstreamDelta);
+  upstreamSawDone = initialStreamResult.sawDone;
+  upstreamEventCount = initialStreamResult.eventCount;
 
   // required 重试
-  if (parser && !parser.hasEmittedAnyCall() && requiresToolCall(toolChoice)) {
+  if (
+    parser &&
+    !parser.hasEmittedAnyCall() &&
+    !nativeToolAccumulator?.hasAny() &&
+    requiresToolCall(toolChoice)
+  ) {
     const retryBody = appendRetryHint(requestBody, buildRetryHint(toolChoice));
     logger.warning?.('Anthropic 流式: tool_choice=required 首次未触发，重试一次', 'ANTHROPIC');
     try {
       const retryResp = await sendChatRequest(retryBody);
       if (retryResp.status && retryResp.response) {
-        await consumeUpstream(retryResp.response, onUpstreamDelta);
+        upstreamFinishReason = null;
+        const retryResult = await consumeUpstream(retryResp.response, onUpstreamDelta);
+        upstreamSawDone = retryResult.sawDone;
+        upstreamEventCount = retryResult.eventCount;
       }
     } catch (e) {
       logger.error('Anthropic 流式重试失败', 'ANTHROPIC', '', e);
@@ -558,10 +606,42 @@ const handleAnthropicStream = async (res, ctx, upstream) => {
     for (const call of tail.completedCalls) emitToolUse(call);
   }
 
+  const nativeToolCalls = nativeToolAccumulator?.hasAny()
+    ? nativeToolAccumulator.finalize()
+    : [];
+  for (const call of nativeToolCalls) emitToolUse(call);
+
+  const hasEmittedToolCalls = !!(
+    nativeToolCalls.length > 0 ||
+    (parser && parser.hasEmittedAnyCall())
+  );
+  const hasToolProtocolError = !!(
+    !hasEmittedToolCalls &&
+    (requiresToolCall(toolChoice) ||
+      (parser && parser.hasParseError()) ||
+      (nativeToolAccumulator && nativeToolAccumulator.hasParseError()))
+  );
+
+  if (hasToolProtocolError) {
+    closeThinkingBlockIfOpen();
+    closeTextBlockIfOpen();
+    writeAnthropicError(res, '上游返回了残缺、非法或不存在的工具调用', 'invalid_tool_call_error');
+    return;
+  }
+
   closeThinkingBlockIfOpen();
   closeTextBlockIfOpen();
 
-  const stopReason = (parser && parser.hasEmittedAnyCall()) ? 'tool_use' : 'end_turn';
+  const stopReason = mapAnthropicStopReason(
+    upstreamFinishReason,
+    hasEmittedToolCalls,
+    upstreamSawDone
+  );
+  if (!stopReason) {
+    const detail = upstreamEventCount === 0 ? '上游未返回任何 SSE 事件' : '上游流在结束标记前断开';
+    writeAnthropicError(res, detail, 'api_error');
+    return;
+  }
 
   if (promptTokens === 0 && completionTokens === 0) {
     const usage = createUsageObject(requestBody?.messages || '', completionContent, null);
@@ -589,13 +669,19 @@ const handleAnthropicStream = async (res, ctx, upstream) => {
  * @returns {Promise<void>} 完成 Promise
  */
 const handleAnthropicNonStream = async (res, ctx, upstream) => {
-  const { message_id, model, hasTools, toolChoice, requestBody } = ctx;
+  const { message_id, model, hasTools, toolChoice, requestBody, allowedToolNames = [] } = ctx;
 
   let thinkingContent = '';
   let answerContent = '';
   let promptTokens = 0;
   let completionTokens = 0;
   let webSearchInfo = null;
+  let upstreamFinishReason = null;
+  let upstreamSawDone = false;
+  let upstreamEventCount = 0;
+  let nativeToolAccumulator = hasTools
+    ? createNativeToolCallAccumulator({ allowedToolNames })
+    : null;
   const normalizeDelta = createUpstreamDeltaNormalizer();
 
   /**
@@ -603,12 +689,22 @@ const handleAnthropicNonStream = async (res, ctx, upstream) => {
    * @param {Object} json - 上游 SSE delta
    */
   const onUpstreamDelta = async (json) => {
-    if (!json.choices || json.choices.length === 0) return;
     if (json.usage) {
       promptTokens = json.usage.prompt_tokens || promptTokens;
       completionTokens = json.usage.completion_tokens || completionTokens;
     }
-    const delta = json.choices[0].delta;
+    if (!json.choices || json.choices.length === 0) return;
+    const choice = json.choices[0];
+    const reportedFinishReason = choice.finish_reason ?? choice.delta?.finish_reason;
+    if (reportedFinishReason !== undefined && reportedFinishReason !== null) {
+      upstreamFinishReason = reportedFinishReason;
+    }
+    const delta = choice.delta || {};
+    if (nativeToolAccumulator && Array.isArray(delta.tool_calls)) {
+      nativeToolAccumulator.push(delta.tool_calls);
+    } else if (nativeToolAccumulator && delta.function_call) {
+      nativeToolAccumulator.push([{ index: 0, type: 'function', function: delta.function_call }]);
+    }
     if (delta && delta.name === 'web_search') {
       webSearchInfo = delta.extra?.web_search_info;
     }
@@ -623,7 +719,17 @@ const handleAnthropicNonStream = async (res, ctx, upstream) => {
     }
   };
 
-  await consumeUpstream(upstream, onUpstreamDelta);
+  const initialStreamResult = await consumeUpstream(upstream, onUpstreamDelta);
+  upstreamSawDone = initialStreamResult.sawDone;
+  upstreamEventCount = initialStreamResult.eventCount;
+
+  if (!upstreamSawDone && !upstreamFinishReason) {
+    const detail = upstreamEventCount === 0 ? '上游未返回任何 SSE 事件' : '上游流在结束标记前断开';
+    return res.status(502).json({
+      type: 'error',
+      error: { type: 'api_error', message: detail }
+    });
+  }
 
   if (webSearchInfo) {
     const config = require('../config/index.js');
@@ -637,9 +743,19 @@ const handleAnthropicNonStream = async (res, ctx, upstream) => {
     } catch (_) {}
   }
 
-  let { cleanedText, toolCalls } = hasTools
-    ? parseToolCallsFromText(answerContent)
-    : { cleanedText: answerContent, toolCalls: [] };
+  let parsedTools = hasTools
+    ? parseToolCallsFromText(answerContent, { allowedToolNames })
+    : { cleanedText: answerContent, toolCalls: [], errors: [] };
+  let cleanedText = parsedTools.cleanedText;
+  let nativeToolCalls = nativeToolAccumulator?.hasAny()
+    ? nativeToolAccumulator.finalize()
+    : [];
+  let toolCalls = [...nativeToolCalls, ...parsedTools.toolCalls]
+    .map((call, index) => ({ ...call, index }));
+  let toolErrors = [
+    ...parsedTools.errors,
+    ...(nativeToolAccumulator?.getErrors() || [])
+  ];
 
   // required 重试
   if (hasTools && toolCalls.length === 0 && requiresToolCall(toolChoice)) {
@@ -648,17 +764,52 @@ const handleAnthropicNonStream = async (res, ctx, upstream) => {
       const retryResp = await sendChatRequest(appendRetryHint(requestBody, buildRetryHint(toolChoice)));
       if (retryResp.status && retryResp.response) {
         const before = answerContent;
-        await consumeUpstream(retryResp.response, onUpstreamDelta);
-        const retried = answerContent.slice(before.length);
-        const parsedRetry = parseToolCallsFromText(retried);
-        if (parsedRetry.toolCalls.length > 0) {
-          toolCalls = parsedRetry.toolCalls;
-          cleanedText = parseToolCallsFromText(answerContent).cleanedText;
+        nativeToolAccumulator = createNativeToolCallAccumulator({ allowedToolNames });
+        upstreamFinishReason = null;
+        const retryResult = await consumeUpstream(retryResp.response, onUpstreamDelta);
+        upstreamSawDone = retryResult.sawDone;
+        upstreamEventCount = retryResult.eventCount;
+        if (!upstreamSawDone && !upstreamFinishReason) {
+          return res.status(502).json({
+            type: 'error',
+            error: { type: 'api_error', message: '工具调用重试流在结束标记前断开' }
+          });
         }
+        const retried = answerContent.slice(before.length);
+        const parsedRetry = parseToolCallsFromText(retried, { allowedToolNames });
+        nativeToolCalls = nativeToolAccumulator.hasAny()
+          ? nativeToolAccumulator.finalize()
+          : [];
+        toolCalls = [...nativeToolCalls, ...parsedRetry.toolCalls]
+          .map((call, index) => ({ ...call, index }));
+        cleanedText = parsedRetry.cleanedText;
+        toolErrors = [...parsedRetry.errors, ...nativeToolAccumulator.getErrors()];
       }
     } catch (e) {
       logger.error('Anthropic 非流式重试失败', 'ANTHROPIC', '', e);
     }
+  }
+
+  if (hasTools && toolCalls.length === 0 && (toolErrors.length > 0 || requiresToolCall(toolChoice))) {
+    return res.status(502).json({
+      type: 'error',
+      error: {
+        type: 'invalid_tool_call_error',
+        message: '上游返回了残缺、非法或不存在的工具调用'
+      }
+    });
+  }
+
+  const stopReason = mapAnthropicStopReason(
+    upstreamFinishReason,
+    toolCalls.length > 0,
+    upstreamSawDone
+  );
+  if (!stopReason) {
+    return res.status(502).json({
+      type: 'error',
+      error: { type: 'api_error', message: '上游流在结束标记前断开' }
+    });
   }
 
   if (promptTokens === 0 && completionTokens === 0) {
@@ -669,7 +820,11 @@ const handleAnthropicNonStream = async (res, ctx, upstream) => {
 
   const contentBlocks = [];
   if (thinkingContent && thinkingContent.trim()) {
-    contentBlocks.push({ type: 'thinking', thinking: thinkingContent });
+    contentBlocks.push({
+      type: 'thinking',
+      thinking: thinkingContent,
+      signature: `qwen2api_${generateUUID().replace(/-/g, '')}`
+    });
   }
   if (cleanedText && cleanedText.trim()) {
     contentBlocks.push({ type: 'text', text: cleanedText });
@@ -695,7 +850,7 @@ const handleAnthropicNonStream = async (res, ctx, upstream) => {
     role: 'assistant',
     model,
     content: contentBlocks,
-    stop_reason: toolCalls.length > 0 ? 'tool_use' : 'end_turn',
+    stop_reason: stopReason,
     stop_sequence: null,
     usage: { input_tokens: promptTokens, output_tokens: completionTokens }
   });
@@ -719,7 +874,7 @@ const handleAnthropicMessages = async (req, res) => {
     }
 
     const built = await buildInternalRequest(req.body || {});
-    const { body, hasTools, toolChoice, model } = built;
+    const { body, hasTools, toolChoice, allowedToolNames, model } = built;
 
     const upstreamResp = await sendChatRequest(body);
     if (!upstreamResp.status || !upstreamResp.response) {
@@ -730,7 +885,15 @@ const handleAnthropicMessages = async (req, res) => {
     }
 
     const message_id = `msg_${generateUUID().replace(/-/g, '').slice(0, 24)}`;
-    const ctx = { message_id, model, hasTools, toolChoice, requestBody: body, currentAccount: upstreamResp.currentAccount };
+    const ctx = {
+      message_id,
+      model,
+      hasTools,
+      toolChoice,
+      allowedToolNames,
+      requestBody: body,
+      currentAccount: upstreamResp.currentAccount
+    };
 
     if (req.body?.stream) {
       await handleAnthropicStream(res, ctx, upstreamResp.response);
@@ -745,7 +908,9 @@ const handleAnthropicMessages = async (req, res) => {
         error: { type: 'api_error', message: 'Service error' }
       });
     } else {
-      try { res.end(); } catch (_) { /* ignore */ }
+      if (!res.writableEnded) {
+        try { writeAnthropicError(res, '上游响应处理失败', 'api_error'); } catch (_) { /* ignore */ }
+      }
     }
   }
 };
@@ -758,5 +923,9 @@ module.exports = {
   flattenAnthropicMessages,
   normalizeAnthropicTools,
   normalizeAnthropicToolChoice,
-  normalizeAnthropicSystem
+  normalizeAnthropicSystem,
+  mapAnthropicStopReason,
+  consumeUpstream,
+  handleAnthropicStream,
+  handleAnthropicNonStream
 };

--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -1,12 +1,43 @@
 const { isJson, generateUUID } = require('../utils/tools.js')
 const { createUsageObject } = require('../utils/precise-tokenizer.js')
 const { sendChatRequest } = require('../utils/request.js')
-const { createToolCallStreamParser, parseToolCallsFromText } = require('../utils/tool-prompt.js')
+const {
+    createToolCallStreamParser,
+    parseToolCallsFromText,
+    createNativeToolCallAccumulator
+} = require('../utils/tool-prompt.js')
+const { consumeSSEStream } = require('../utils/sse.js')
 const accountManager = require('../utils/account.js')
 const config = require('../config/index.js')
-const axios = require('axios')
 const { logger } = require('../utils/logger')
 const { createUpstreamDeltaNormalizer } = require('../utils/chat-helpers.js')
+
+const normalizeOpenAIFinishReason = (upstreamReason, hasToolCalls, sawDone) => {
+    if (hasToolCalls) return 'tool_calls'
+    if (typeof upstreamReason === 'string' && upstreamReason.length > 0) {
+        const aliases = {
+            end_turn: 'stop',
+            max_tokens: 'length',
+            tool_use: 'tool_calls'
+        }
+        const normalized = aliases[upstreamReason] || upstreamReason
+        const supported = new Set(['stop', 'length', 'tool_calls', 'content_filter', 'function_call'])
+        return supported.has(normalized) ? normalized : null
+    }
+    return sawDone ? 'stop' : null
+}
+
+const writeOpenAIStreamError = (res, message, code = 'upstream_incomplete') => {
+    res.write(`data: ${JSON.stringify({
+        error: {
+            message,
+            type: 'upstream_stream_error',
+            code
+        }
+    })}\n\n`)
+    res.write('data: [DONE]\n\n')
+    res.end()
+}
 
 /**
  * 设置响应头
@@ -70,6 +101,28 @@ const buildRequiredRetryHint = (toolChoice) => {
     return 'You did not call any tool in your previous reply. You MUST now call exactly one tool using the <tool_call>...</tool_call> format and nothing else.'
 }
 
+const appendRetryHintToRequestBody = (requestBody, hint) => {
+    const messages = Array.isArray(requestBody?.messages)
+        ? requestBody.messages.map(message => ({ ...message }))
+        : []
+    if (messages.length === 0) {
+        messages.push({ role: 'user', content: hint })
+    } else {
+        const last = messages[messages.length - 1]
+        if (typeof last.content === 'string') {
+            last.content = `${last.content}\n\n# Tool-call retry\n${hint}`
+        } else if (Array.isArray(last.content)) {
+            const textPart = last.content.find(part => part?.type === 'text')
+            if (textPart) {
+                textPart.text = `${textPart.text || ''}\n\n# Tool-call retry\n${hint}`
+            } else {
+                last.content = [{ type: 'text', text: hint }, ...last.content]
+            }
+        }
+    }
+    return { ...requestBody, messages }
+}
+
 /**
  * 处理流式响应
  * @param {object} res - Express 响应对象
@@ -110,7 +163,14 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
 
         const hasTools = !!options.has_tools
         const toolChoice = options.tool_choice
-        const toolParser = hasTools ? createToolCallStreamParser() : null
+        const allowedToolNames = options.allowed_tool_names || []
+        const toolParser = hasTools ? createToolCallStreamParser({ allowedToolNames }) : null
+        let nativeToolAccumulator = hasTools
+            ? createNativeToolCallAccumulator({ allowedToolNames })
+            : null
+        let upstreamFinishReason = null
+        let upstreamSawDone = false
+        let upstreamEventCount = 0
 
         // Token消耗量统计
         let totalTokens = {
@@ -258,9 +318,7 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
          */
         const processSSEPayload = async (dataContent) => {
             const decodeJson = isJson(dataContent) ? JSON.parse(dataContent) : null
-            if (decodeJson === null || !decodeJson.choices || decodeJson.choices.length === 0) {
-                return
-            }
+            if (decodeJson === null) return
 
             if (decodeJson.usage) {
                 totalTokens = {
@@ -270,7 +328,24 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
                 }
             }
 
-            const delta = decodeJson.choices[0].delta
+            if (!decodeJson.choices || decodeJson.choices.length === 0) return
+
+            const choice = decodeJson.choices[0]
+            const reportedFinishReason = choice.finish_reason ?? choice.delta?.finish_reason
+            if (reportedFinishReason !== undefined && reportedFinishReason !== null) {
+                upstreamFinishReason = reportedFinishReason
+            }
+
+            const delta = choice.delta || {}
+            if (nativeToolAccumulator && Array.isArray(delta.tool_calls)) {
+                nativeToolAccumulator.push(delta.tool_calls)
+            } else if (nativeToolAccumulator && delta.function_call) {
+                nativeToolAccumulator.push([{
+                    index: 0,
+                    type: 'function',
+                    function: delta.function_call
+                }])
+            }
 
             if (delta && delta.name === 'web_search') {
                 web_search_info = delta.extra.web_search_info
@@ -369,60 +444,37 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
          * @param {object} upstreamResponse - axios stream 响应
          * @returns {Promise<void>} 流处理完成的 Promise
          */
-        const pipeUpstream = (upstreamResponse) => new Promise((resolve, reject) => {
-            const decoder = new TextDecoder('utf-8')
-            let buffer = ''
-
-            upstreamResponse.on('data', async (chunk) => {
-                const decodeText = decoder.decode(chunk, { stream: true })
-                buffer += decodeText
-
-                const chunks = []
-                let startIndex = 0
-
-                while (true) {
-                    const dataStart = buffer.indexOf('data: ', startIndex)
-                    if (dataStart === -1) break
-                    const dataEnd = buffer.indexOf('\n\n', dataStart)
-                    if (dataEnd === -1) break
-                    const dataChunk = buffer.substring(dataStart, dataEnd).trim()
-                    chunks.push(dataChunk)
-                    startIndex = dataEnd + 2
-                }
-
-                if (startIndex > 0) {
-                    buffer = buffer.substring(startIndex)
-                }
-
-                for (const item of chunks) {
-                    try {
-                        await processSSEPayload(item.replace("data: ", ''))
-                    } catch (error) {
-                        logger.error('流式数据处理错误', 'CHAT', '', error)
-                    }
+        const pipeUpstream = async (upstreamResponse) => {
+            const result = await consumeSSEStream(upstreamResponse, async (frame) => {
+                if (!frame.data || frame.data.trim() === '[DONE]') return
+                try {
+                    await processSSEPayload(frame.data)
+                } catch (error) {
+                    logger.error('流式数据处理错误', 'CHAT', '', error)
+                    throw error
                 }
             })
-
-            upstreamResponse.on('end', () => resolve())
-            upstreamResponse.on('error', (err) => reject(err))
-        })
+            upstreamSawDone = result.sawDone
+            upstreamEventCount = result.eventCount
+        }
 
         await pipeUpstream(response)
 
         // tool_choice="required" 强校验：未触发任何工具调用则追加更强提示重试一次
-        if (hasTools && toolParser && !toolParser.hasEmittedAnyCall() && requiresToolCall(toolChoice)) {
+        if (
+            hasTools &&
+            toolParser &&
+            !toolParser.hasEmittedAnyCall() &&
+            !nativeToolAccumulator?.hasAny() &&
+            requiresToolCall(toolChoice)
+        ) {
             const retryHint = buildRequiredRetryHint(toolChoice)
-            const retryBody = {
-                ...requestBody,
-                messages: [
-                    ...(Array.isArray(requestBody?.messages) ? requestBody.messages : []),
-                    { role: 'system', content: retryHint }
-                ]
-            }
+            const retryBody = appendRetryHintToRequestBody(requestBody, retryHint)
             logger.warning?.('tool_choice=required 首次未触发工具调用，进行一次重试', 'CHAT')
             try {
                 const retryResp = await sendChatRequest(retryBody)
                 if (retryResp.status && retryResp.response) {
+                    upstreamFinishReason = null
                     await pipeUpstream(retryResp.response)
                 }
             } catch (e) {
@@ -435,6 +487,37 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
             const tail = toolParser.flush()
             if (tail.textDelta) writeContentDelta(tail.textDelta)
             if (tail.completedCalls.length > 0) writeToolCallsDelta(tail.completedCalls)
+        }
+
+        const nativeToolCalls = nativeToolAccumulator?.hasAny()
+            ? nativeToolAccumulator.finalize()
+            : []
+        if (nativeToolCalls.length > 0) writeToolCallsDelta(nativeToolCalls)
+
+        const hasEmittedToolCalls = !!(
+            nativeToolCalls.length > 0 ||
+            (toolParser && toolParser.hasEmittedAnyCall())
+        )
+        const hasToolProtocolError = !!(
+            !hasEmittedToolCalls &&
+            (requiresToolCall(toolChoice) ||
+                (toolParser && toolParser.hasParseError()) ||
+                (nativeToolAccumulator && nativeToolAccumulator.hasParseError()))
+        )
+        if (hasToolProtocolError) {
+            writeOpenAIStreamError(res, '上游返回了残缺、非法或不存在的工具调用', 'invalid_tool_call')
+            return
+        }
+
+        const finishReason = normalizeOpenAIFinishReason(
+            upstreamFinishReason,
+            hasEmittedToolCalls,
+            upstreamSawDone
+        )
+        if (!finishReason) {
+            const detail = upstreamEventCount === 0 ? '上游未返回任何 SSE 事件' : '上游流在结束标记前断开'
+            writeOpenAIStreamError(res, detail, 'upstream_incomplete')
+            return
         }
 
         // 处理最终的搜索信息
@@ -465,7 +548,6 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
         // 全归属主账户是可接受的精度损失（PR #3wg.1 epic notes 已记）
         attributeChatUsage(options.currentAccount, totalTokens)
 
-        const finishReason = (toolParser && toolParser.hasEmittedAnyCall()) ? 'tool_calls' : 'stop'
         res.write(`data: ${JSON.stringify({
             "id": `chatcmpl-${message_id}`,
             "object": "chat.completion.chunk",
@@ -491,7 +573,19 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
         res.end()
     } catch (error) {
         logger.error('聊天处理错误', 'CHAT', '', error)
-        try { res.status(500).json({ error: "Service error" }) } catch (_) { /* response already started */ }
+        if (res.headersSent) {
+            if (!res.writableEnded) {
+                writeOpenAIStreamError(res, '上游流式传输失败', 'upstream_stream_error')
+            }
+        } else {
+            res.status(502).json({
+                error: {
+                    message: '上游流式传输失败',
+                    type: 'upstream_stream_error',
+                    code: 'upstream_stream_error'
+                }
+            })
+        }
     }
 }
 
@@ -519,6 +613,13 @@ const handleNonStreamResponse = async (res, response, enable_thinking, enable_we
 
         const hasTools = !!options.has_tools
         const toolChoice = options.tool_choice
+        const allowedToolNames = options.allowed_tool_names || []
+        let nativeToolAccumulator = hasTools
+            ? createNativeToolCallAccumulator({ allowedToolNames })
+            : null
+        let upstreamFinishReason = null
+        let upstreamSawDone = false
+        let upstreamEventCount = 0
 
         // Token消耗量统计
         let totalTokens = {
@@ -545,168 +646,190 @@ const handleNonStreamResponse = async (res, response, enable_thinking, enable_we
          * @param {object} upstreamResponse - axios stream 响应
          * @returns {Promise<void>} 流处理完成的 Promise
          */
-        const accumulateUpstream = (upstreamResponse) => new Promise((resolve, reject) => {
-            const decoder = new TextDecoder('utf-8')
-            let buffer = ''
+        const processAccumulatedPayload = async (dataContent) => {
+            const decodeJson = isJson(dataContent) ? JSON.parse(dataContent) : null
+            if (decodeJson === null) return
 
-            upstreamResponse.on('data', async (chunk) => {
-                const decodeText = decoder.decode(chunk, { stream: true })
-                buffer += decodeText
-
-                const chunks = []
-                let startIndex = 0
-
-                while (true) {
-                    const dataStart = buffer.indexOf('data: ', startIndex)
-                    if (dataStart === -1) break
-                    const dataEnd = buffer.indexOf('\n\n', dataStart)
-                    if (dataEnd === -1) break
-                    const dataChunk = buffer.substring(dataStart, dataEnd).trim()
-                    chunks.push(dataChunk)
-                    startIndex = dataEnd + 2
+            if (decodeJson.usage) {
+                totalTokens = {
+                    prompt_tokens: decodeJson.usage.prompt_tokens || totalTokens.prompt_tokens,
+                    completion_tokens: decodeJson.usage.completion_tokens || totalTokens.completion_tokens,
+                    total_tokens: decodeJson.usage.total_tokens || totalTokens.total_tokens
                 }
+            }
+            if (!decodeJson.choices || decodeJson.choices.length === 0) return
 
-                if (startIndex > 0) {
-                    buffer = buffer.substring(startIndex)
+            const choice = decodeJson.choices[0]
+            const reportedFinishReason = choice.finish_reason ?? choice.delta?.finish_reason
+            if (reportedFinishReason !== undefined && reportedFinishReason !== null) {
+                upstreamFinishReason = reportedFinishReason
+            }
+            const delta = choice.delta || {}
+            if (nativeToolAccumulator && Array.isArray(delta.tool_calls)) {
+                nativeToolAccumulator.push(delta.tool_calls)
+            } else if (nativeToolAccumulator && delta.function_call) {
+                nativeToolAccumulator.push([{ index: 0, type: 'function', function: delta.function_call }])
+            }
+
+            if (delta.name === 'web_search') {
+                web_search_info = delta.extra?.web_search_info
+            }
+
+            const imageMarkdownList = getImageMarkdownListFromDelta(delta)
+            if (imageMarkdownList.length > 0) {
+                const newImageMarkdownList = imageMarkdownList.filter(it => !appendedImageMarkdownSet.has(it))
+                if (thinking_start && !thinking_end) {
+                    for (const imageMarkdown of newImageMarkdownList) {
+                        if (!pendingImageMarkdownList.includes(imageMarkdown)) pendingImageMarkdownList.push(imageMarkdown)
+                    }
+                } else if (newImageMarkdownList.length > 0) {
+                    fullContent += `${newImageMarkdownList.join('\n\n')}\n\n`
+                    newImageMarkdownList.forEach(it => appendedImageMarkdownSet.add(it))
                 }
+            }
 
-                for (const item of chunks) {
-                    try {
-                        const dataContent = item.replace("data: ", '')
-                        const decodeJson = isJson(dataContent) ? JSON.parse(dataContent) : null
-                        if (decodeJson === null || !decodeJson.choices || decodeJson.choices.length === 0) {
-                            continue
-                        }
+            const normalized = normalizeDelta(delta)
+            if (!normalized) return
+            delta.phase = normalized.phase
+            let content = normalized.content
 
-                        if (decodeJson.usage) {
-                            totalTokens = {
-                                prompt_tokens: decodeJson.usage.prompt_tokens || totalTokens.prompt_tokens,
-                                completion_tokens: decodeJson.usage.completion_tokens || totalTokens.completion_tokens,
-                                total_tokens: decodeJson.usage.total_tokens || totalTokens.total_tokens
-                            }
-                        }
-
-                        const delta = decodeJson.choices[0].delta
-
-                        if (delta && delta.name === 'web_search') {
-                            web_search_info = delta.extra.web_search_info
-                        }
-
-                        const imageMarkdownList = getImageMarkdownListFromDelta(delta)
-                        if (imageMarkdownList.length > 0) {
-                            const newImageMarkdownList = imageMarkdownList.filter(it => !appendedImageMarkdownSet.has(it))
-
-                            if (thinking_start && !thinking_end) {
-                                for (const imageMarkdown of newImageMarkdownList) {
-                                    if (!pendingImageMarkdownList.includes(imageMarkdown)) {
-                                        pendingImageMarkdownList.push(imageMarkdown)
-                                    }
-                                }
-                            } else if (newImageMarkdownList.length > 0) {
-                                fullContent += `${newImageMarkdownList.join('\n\n')}\n\n`
-                                newImageMarkdownList.forEach(it => appendedImageMarkdownSet.add(it))
-                            }
-                        }
-
-                        const normalized = normalizeDelta(delta)
-                        if (!normalized) {
-                            continue
-                        }
-                        delta.phase = normalized.phase
-                        let content = normalized.content
-
-                        if (config.legacyReasoningInContent) {
-                            // 旧版：推理以 <think>...</think> 包裹并入 content
-                            if (delta.phase === 'think' && !thinking_start) {
-                                thinking_start = true
-                                if (web_search_info) {
-                                    const webSearchTable = await accountManager.generateMarkdownTable(web_search_info, config.searchInfoMode)
-                                    content = `<think>\n\n${webSearchTable}\n\n${content}`
-                                } else {
-                                    content = `<think>\n\n${content}`
-                                }
-                            }
-                            if (delta.phase === 'answer' && !thinking_end && thinking_start) {
-                                thinking_end = true
-                                if (pendingImageMarkdownList.length > 0) {
-                                    content = `\n\n</think>\n${pendingImageMarkdownList.join('\n\n')}\n\n${content}`
-                                    pendingImageMarkdownList.forEach(it => appendedImageMarkdownSet.add(it))
-                                    pendingImageMarkdownList = []
-                                } else {
-                                    content = `\n\n</think>\n${content}`
-                                }
-                            }
-                            fullContent += content
-                        } else if (delta.phase === 'think') {
-                            // 新版：推理累积到 reasoning_content
-                            if (!thinking_start && web_search_info) {
-                                const webSearchTable = await accountManager.generateMarkdownTable(web_search_info, config.searchInfoMode)
-                                content = `${webSearchTable}\n\n${content}`
-                            }
-                            thinking_start = true
-                            fullReasoning += content
-                        } else {
-                            // 新版 answer 阶段：先冲刷缓存图片，再累积正文
-                            if (!thinking_end && thinking_start) {
-                                thinking_end = true
-                                if (pendingImageMarkdownList.length > 0) {
-                                    fullContent += `${pendingImageMarkdownList.join('\n\n')}\n\n`
-                                    pendingImageMarkdownList.forEach(it => appendedImageMarkdownSet.add(it))
-                                    pendingImageMarkdownList = []
-                                }
-                            }
-                            fullContent += content
-                        }
-                    } catch (error) {
-                        logger.error('非流式数据处理错误', 'CHAT', '', error)
+            if (config.legacyReasoningInContent) {
+                if (delta.phase === 'think' && !thinking_start) {
+                    thinking_start = true
+                    if (web_search_info) {
+                        const webSearchTable = await accountManager.generateMarkdownTable(web_search_info, config.searchInfoMode)
+                        content = `<think>\n\n${webSearchTable}\n\n${content}`
+                    } else {
+                        content = `<think>\n\n${content}`
                     }
                 }
-            })
+                if (delta.phase === 'answer' && !thinking_end && thinking_start) {
+                    thinking_end = true
+                    if (pendingImageMarkdownList.length > 0) {
+                        content = `\n\n</think>\n${pendingImageMarkdownList.join('\n\n')}\n\n${content}`
+                        pendingImageMarkdownList.forEach(it => appendedImageMarkdownSet.add(it))
+                        pendingImageMarkdownList = []
+                    } else {
+                        content = `\n\n</think>\n${content}`
+                    }
+                }
+                fullContent += content
+            } else if (delta.phase === 'think') {
+                if (!thinking_start && web_search_info) {
+                    const webSearchTable = await accountManager.generateMarkdownTable(web_search_info, config.searchInfoMode)
+                    content = `${webSearchTable}\n\n${content}`
+                }
+                thinking_start = true
+                fullReasoning += content
+            } else {
+                if (!thinking_end && thinking_start) {
+                    thinking_end = true
+                    if (pendingImageMarkdownList.length > 0) {
+                        fullContent += `${pendingImageMarkdownList.join('\n\n')}\n\n`
+                        pendingImageMarkdownList.forEach(it => appendedImageMarkdownSet.add(it))
+                        pendingImageMarkdownList = []
+                    }
+                }
+                fullContent += content
+            }
+        }
 
-            upstreamResponse.on('end', () => resolve())
-            upstreamResponse.on('error', (err) => {
-                logger.error('非流式响应流读取错误', 'CHAT', '', err)
-                reject(err)
+        const accumulateUpstream = async (upstreamResponse) => {
+            const result = await consumeSSEStream(upstreamResponse, async (frame) => {
+                if (!frame.data || frame.data.trim() === '[DONE]') return
+                await processAccumulatedPayload(frame.data)
             })
-        })
+            upstreamSawDone = result.sawDone
+            upstreamEventCount = result.eventCount
+        }
 
         await accumulateUpstream(response)
 
-        // 工具调用解析：从 fullContent 抽取 <tool_call> 块
+        if (!upstreamSawDone && !upstreamFinishReason) {
+            const detail = upstreamEventCount === 0 ? '上游未返回任何 SSE 事件' : '上游流在结束标记前断开'
+            return res.status(502).json({
+                error: { message: detail, type: 'upstream_stream_error', code: 'upstream_incomplete' }
+            })
+        }
+
+        // 同时支持提示词/XML 工具调用与上游原生 delta.tool_calls。
         let assistantContent = fullContent
         let toolCalls = []
+        let toolErrors = []
         if (hasTools) {
-            const parsed = parseToolCallsFromText(fullContent)
+            const parsed = parseToolCallsFromText(fullContent, { allowedToolNames })
+            const nativeCalls = nativeToolAccumulator?.hasAny() ? nativeToolAccumulator.finalize() : []
             assistantContent = parsed.cleanedText
-            toolCalls = parsed.toolCalls
+            toolCalls = [...nativeCalls, ...parsed.toolCalls].map((call, index) => ({ ...call, index }))
+            toolErrors = [
+                ...parsed.errors,
+                ...(nativeToolAccumulator?.getErrors() || [])
+            ]
         }
 
         // tool_choice="required" 强校验：未触发则重试一次
         if (hasTools && toolCalls.length === 0 && requiresToolCall(toolChoice)) {
             const retryHint = buildRequiredRetryHint(toolChoice)
-            const retryBody = {
-                ...requestBody,
-                messages: [
-                    ...(Array.isArray(requestBody?.messages) ? requestBody.messages : []),
-                    { role: 'system', content: retryHint }
-                ]
-            }
+            const retryBody = appendRetryHintToRequestBody(requestBody, retryHint)
             logger.warning?.('tool_choice=required 首次未触发工具调用，进行一次重试', 'CHAT')
             try {
                 const retryResp = await sendChatRequest(retryBody)
                 if (retryResp.status && retryResp.response) {
                     const before = fullContent
+                    nativeToolAccumulator = createNativeToolCallAccumulator({ allowedToolNames })
+                    upstreamFinishReason = null
                     await accumulateUpstream(retryResp.response)
-                    const retriedText = fullContent.slice(before.length)
-                    const parsedRetry = parseToolCallsFromText(retriedText)
-                    if (parsedRetry.toolCalls.length > 0) {
-                        toolCalls = parsedRetry.toolCalls
-                        assistantContent = (parseToolCallsFromText(fullContent).cleanedText)
+                    if (!upstreamSawDone && !upstreamFinishReason) {
+                        return res.status(502).json({
+                            error: {
+                                message: '工具调用重试流在结束标记前断开',
+                                type: 'upstream_stream_error',
+                                code: 'upstream_incomplete'
+                            }
+                        })
                     }
+                    const retriedText = fullContent.slice(before.length)
+                    const parsedRetry = parseToolCallsFromText(retriedText, { allowedToolNames })
+                    const nativeRetryCalls = nativeToolAccumulator.hasAny()
+                        ? nativeToolAccumulator.finalize()
+                        : []
+                    toolCalls = [...nativeRetryCalls, ...parsedRetry.toolCalls]
+                        .map((call, index) => ({ ...call, index }))
+                    assistantContent = parsedRetry.cleanedText
+                    toolErrors = [
+                        ...parsedRetry.errors,
+                        ...nativeToolAccumulator.getErrors()
+                    ]
                 }
             } catch (e) {
                 logger.error('required 模式重试失败', 'CHAT', '', e)
             }
+        }
+
+        if (hasTools && toolCalls.length === 0 && (toolErrors.length > 0 || requiresToolCall(toolChoice))) {
+            return res.status(502).json({
+                error: {
+                    message: '上游返回了残缺、非法或不存在的工具调用',
+                    type: 'invalid_tool_call',
+                    code: 'invalid_tool_call',
+                    details: toolErrors
+                }
+            })
+        }
+
+        const finishReason = normalizeOpenAIFinishReason(
+            upstreamFinishReason,
+            toolCalls.length > 0,
+            upstreamSawDone
+        )
+        if (!finishReason) {
+            return res.status(502).json({
+                error: {
+                    message: '上游流在结束标记前断开',
+                    type: 'upstream_stream_error',
+                    code: 'upstream_incomplete'
+                }
+            })
         }
 
         // 处理最终的搜索信息（同流式分支：新版模式思考开启时搜索表格已在 reasoning_content，不再追加到 content）
@@ -750,7 +873,7 @@ const handleNonStreamResponse = async (res, response, enable_thinking, enable_we
                 {
                     "index": 0,
                     "message": assistantMessage,
-                    "finish_reason": toolCalls.length > 0 ? "tool_calls" : "stop"
+                    "finish_reason": finishReason
                 }
             ],
             "usage": totalTokens
@@ -758,10 +881,15 @@ const handleNonStreamResponse = async (res, response, enable_thinking, enable_we
         res.json(bodyTemplate)
     } catch (error) {
         logger.error('非流式聊天处理错误', 'CHAT', '', error)
-        res.status(500)
-            .json({
-                error: "Service error"
+        if (!res.headersSent) {
+            res.status(502).json({
+                error: {
+                    message: '上游响应处理失败',
+                    type: 'upstream_error',
+                    code: 'upstream_error'
+                }
             })
+        }
     }
 }
 
@@ -790,10 +918,20 @@ const handleChatCompletion = async (req, res) => {
 
         if (stream) {
             setResponseHeaders(res, true)
-            await handleStreamResponse(res, response_data.response, enable_thinking, enable_web_search, req.body, { has_tools: req.has_tools, tool_choice: req.tool_choice, currentAccount: response_data.currentAccount })
+            await handleStreamResponse(res, response_data.response, enable_thinking, enable_web_search, req.body, {
+                has_tools: req.has_tools,
+                tool_choice: req.tool_choice,
+                allowed_tool_names: req.allowed_tool_names,
+                currentAccount: response_data.currentAccount
+            })
         } else {
             setResponseHeaders(res, false)
-            await handleNonStreamResponse(res, response_data.response, enable_thinking, enable_web_search, model, req.body, { has_tools: req.has_tools, tool_choice: req.tool_choice, currentAccount: response_data.currentAccount })
+            await handleNonStreamResponse(res, response_data.response, enable_thinking, enable_web_search, model, req.body, {
+                has_tools: req.has_tools,
+                tool_choice: req.tool_choice,
+                allowed_tool_names: req.allowed_tool_names,
+                currentAccount: response_data.currentAccount
+            })
         }
 
     } catch (error) {
@@ -809,5 +947,6 @@ module.exports = {
     handleChatCompletion,
     handleStreamResponse,
     handleNonStreamResponse,
-    setResponseHeaders
+    setResponseHeaders,
+    normalizeOpenAIFinishReason
 }

--- a/src/controllers/cli.chat.js
+++ b/src/controllers/cli.chat.js
@@ -1,7 +1,8 @@
 const axios = require('axios')
 const { logger } = require('../utils/logger')
 const accountManager = require('../utils/account')
-const { getProxyAgent, getCliBaseUrl, applyProxyToAxiosConfig } = require('../utils/proxy-helper')
+const { getProxyAgent, getCliBaseUrl } = require('../utils/proxy-helper')
+const { consumeSSEStream, formatSSEFrame } = require('../utils/sse')
 
 /**
  * 静默累计 CLI daily stats——异常不影响响应
@@ -281,9 +282,10 @@ function formatCliJsonResponse(data, fallbackModel) {
  * @param {Object} res - Express响应对象
  */
 const handleCliChatCompletion = async (req, res) => {
+    let body = {}
     try {
         const access_token = req.account.cli_info.access_token
-        const body = preprocessCliRequestBody(req.body)
+        body = preprocessCliRequestBody(req.body)
         const isStream = body.stream === true
 
         // 打印当前使用的账号邮箱
@@ -317,7 +319,7 @@ const handleCliChatCompletion = async (req, res) => {
                 'X-Stainless-Runtime': 'node'
             },
             data: body,
-            timeout: 5 * 60 * 1000,
+            timeout: 10 * 60 * 1000,
             validateStatus: function () {
                 return true
             }
@@ -366,60 +368,43 @@ const handleCliChatCompletion = async (req, res) => {
 
         // 处理流式响应
         if (isStream) {
-            // 缓冲 SSE 解析——usage 帧可能跨 TCP 块（仅 split('\n\n') 会丢失），
-            // 沿用 chat.js/anthropic.js 的 buffer + while indexOf('\n\n') 模式
-            let sseBuffer = ''
             let cliUsage = null
-
-            response.data.on('data', (chunk) => {
-                const text = chunk.toString('utf8')
-                // 透传客户端: 逐行回写，保持原有行为
-                const lines = text.split('\n')
-                for (const line of lines) {
-                    if (!line || !line.startsWith('data:')) continue
-                    res.write(`${line}\n\n`)
-                }
-
-                // 解析 usage 帧（带缓冲——帧可能被分块切开）
-                sseBuffer += text
-                let idx
-                while ((idx = sseBuffer.indexOf('\n\n')) !== -1) {
-                    const frame = sseBuffer.slice(0, idx)
-                    sseBuffer = sseBuffer.slice(idx + 2)
-                    if (!frame.startsWith('data:')) continue
-                    const payload = frame.slice(frame.indexOf(':') + 1).trim()
-                    if (!payload || payload === '[DONE]') continue
+            let upstreamFinishReason = null
+            const streamResult = await consumeSSEStream(response.data, async (frame) => {
+                const payload = frame.data.trim()
+                if (payload && payload !== '[DONE]') {
                     try {
                         const parsed = JSON.parse(payload)
                         if (parsed?.usage) cliUsage = parsed.usage
-                    } catch (e) {
-                        // 部分/非法 JSON——继续累计
+                        const reason = parsed?.choices?.[0]?.finish_reason ?? parsed?.choices?.[0]?.delta?.finish_reason
+                        if (reason !== undefined && reason !== null) upstreamFinishReason = reason
+                    } catch (_) {
+                        // 非 JSON 的合法 SSE 事件仍按原语义透传。
                     }
                 }
+                res.write(formatSSEFrame(frame))
             })
 
-            // 处理流错误
-            response.data.on('error', (streamError) => {
-                logger.error(`CLI请求使用账号[${req.account.email}]流式传输失败 - 当前请求数: ${req.account.cli_info.request_number}`, 'CLI', '❌')
-                // 传输错误——记 failure（影响 cooldown）
-                accountManager.recordAccountFailure(req.account.email, streamError?.code)
-                if (!res.headersSent) {
-                    res.status(500).json({
+            if (!streamResult.sawDone && !upstreamFinishReason) {
+                res.write(formatSSEFrame({
+                    data: JSON.stringify({
                         error: {
-                            message: 'stream_error',
-                            type: 'stream_error',
-                            code: 500
+                            message: 'upstream stream ended before a terminal marker',
+                            type: 'upstream_stream_error',
+                            code: 'upstream_incomplete'
                         }
                     })
-                }
-            })
-
-            // 处理流结束
-            response.data.on('end', () => {
-                logger.success(`CLI请求使用账号[${req.account.email}]转发成功 (流式) - 当前请求数: ${req.account.cli_info.request_number}`, 'CLI')
-                attributeCliUsage(req.account.email, cliUsage)
+                }))
+                res.write('data: [DONE]\n\n')
                 res.end()
-            })
+                accountManager.recordAccountFailure(req.account.email, 'UPSTREAM_INCOMPLETE')
+                return
+            }
+
+            if (!streamResult.sawDone) res.write('data: [DONE]\n\n')
+            logger.success(`CLI请求使用账号[${req.account.email}]转发成功 (流式) - 当前请求数: ${req.account.cli_info.request_number}`, 'CLI')
+            attributeCliUsage(req.account.email, cliUsage)
+            res.end()
         } else {
             // 处理JSON响应
             const cliUsage = response.data?.usage
@@ -437,6 +422,23 @@ const handleCliChatCompletion = async (req, res) => {
             accountManager.recordAccountError(req.account.email, error.response.status)
         } else {
             accountManager.recordAccountFailure(req.account.email, error?.code)
+        }
+
+        if (res.headersSent) {
+            if (!res.writableEnded) {
+                res.write(formatSSEFrame({
+                    data: JSON.stringify({
+                        error: {
+                            message: 'upstream stream transport failed',
+                            type: 'upstream_stream_error',
+                            code: error?.code || 'stream_error'
+                        }
+                    })
+                }))
+                res.write('data: [DONE]\n\n')
+                res.end()
+            }
+            return
         }
 
         // 如果是axios错误，提供更详细的错误信息

--- a/src/middlewares/chat-middleware.js
+++ b/src/middlewares/chat-middleware.js
@@ -82,8 +82,12 @@ const processRequestBody = async (req, res, next) => {
       preparedMessages = foldToolMessages(messages || [])
       req.has_tools = true
       req.tool_choice = tool_choice || 'auto'
+      req.allowed_tool_names = tools
+        .map(tool => tool?.function?.name)
+        .filter(name => typeof name === 'string' && name.length > 0)
     } else {
       req.has_tools = false
+      req.allowed_tool_names = []
     }
 
     // 处理 messages 参数 : 消息历史（返回 OpenAI 格式消息数组）

--- a/src/utils/chat-helpers.js
+++ b/src/utils/chat-helpers.js
@@ -287,7 +287,7 @@ const extractTextFromContent = (content) => {
 const formatSingleMessage = (message) => {
     const role = message.role
     const content = extractTextFromContent(message.content)
-    return content.trim() ? `${role}:${content}` : ''
+    return content.trim() ? JSON.stringify({ role, content }) : ''
 }
 
 /**
@@ -305,7 +305,7 @@ const formatHistoryMessages = (messages) => {
         }
     }
     
-    return formattedParts.length > 0 ? formattedParts.join(';') : ''
+    return formattedParts.length > 0 ? formattedParts.join('\n') : ''
 }
 
 /**
@@ -355,15 +355,19 @@ const parserMessages = async (messages, thinking_config, chat_type) => {
             }
         }
 
-        // 组合最终内容:历史文本 + 当前消息（带角色标注）
-        let combinedText = ''
+        // 网页上游只接受一个当前消息，因此用 JSONL 信封无损保留角色和换行。
+        // 旧版用分号拼接 role:content，内容自身含分号/冒号时会破坏消息边界。
+        const envelopeParts = []
         if (historyText) {
-            combinedText = historyText + ';'
+            envelopeParts.push('# Conversation history (JSONL)', historyText)
         }
-        // 添加最后一条消息，带角色标注
         if (lastMessageText.trim()) {
-            combinedText += `${lastMessageRole}:${lastMessageText}`
+            envelopeParts.push('# Current message', JSON.stringify({
+                role: lastMessageRole,
+                content: lastMessageText
+            }))
         }
+        const combinedText = envelopeParts.join('\n')
 
         // 如果有图片,创建包含文本和图片的content数组
         if (finalContent.length > 0) {
@@ -498,6 +502,7 @@ const processOriginalLogic = async (messages, thinking_config, chat_type, imgCac
  * @returns {boolean}
  */
 const isThinkPhase = (phase) => phase === 'think' || phase === 'thinking' || phase === 'thinking_summary'
+const ANSWER_PHASES = new Set(['answer', 'final', 'final_answer', 'response'])
 
 /**
  * 创建上游 delta 归一化器：将 thinking_summary 的 extra.summary_thought 增量转为 phase=think 的 content
@@ -509,9 +514,19 @@ const createUpstreamDeltaNormalizer = () => {
     return (delta) => {
         if (!delta) return null
         const rawPhase = delta.phase
-        if (!isThinkPhase(rawPhase) && rawPhase !== 'answer') return null
+        const hasReasoningContent = typeof delta.reasoning_content === 'string' && delta.reasoning_content.length > 0
+        const hasContent = typeof delta.content === 'string' && delta.content.length > 0
+        const useReasoningContent = hasReasoningContent && !ANSWER_PHASES.has(rawPhase)
 
-        let content = typeof delta.content === 'string' ? delta.content : ''
+        // 部分模型或上游版本不会返回 phase。此时普通 content 按 answer 处理，
+        // reasoning_content 按 think 处理，避免把完整正文静默丢弃。
+        if (!isThinkPhase(rawPhase) && !ANSWER_PHASES.has(rawPhase) && !hasReasoningContent && !hasContent) {
+            return null
+        }
+
+        let content = useReasoningContent
+            ? delta.reasoning_content
+            : (hasContent ? delta.content : '')
         if (rawPhase === 'thinking_summary') {
             const thoughts = delta.extra && delta.extra.summary_thought && delta.extra.summary_thought.content
             if (Array.isArray(thoughts) && thoughts.length > summaryThoughtCount) {
@@ -524,7 +539,7 @@ const createUpstreamDeltaNormalizer = () => {
 
         if (!content) return null
         return {
-            phase: isThinkPhase(rawPhase) ? 'think' : 'answer',
+            phase: (isThinkPhase(rawPhase) || useReasoningContent) ? 'think' : 'answer',
             content
         }
     }
@@ -535,6 +550,7 @@ module.exports = {
     isThinkingEnabled,
     parserModel,
     parserMessages,
+    formatHistoryMessages,
     isThinkPhase,
     createUpstreamDeltaNormalizer
 }

--- a/src/utils/sse.js
+++ b/src/utils/sse.js
@@ -1,0 +1,154 @@
+const { StringDecoder } = require('node:string_decoder')
+
+/**
+ * 解析单个 SSE frame。
+ * 支持 event/id/retry 以及多行 data 字段；注释行会被忽略。
+ * @param {string} rawFrame
+ * @returns {{event: string|null, data: string, id: string|null, retry: number|null, raw: string}|null}
+ */
+const parseSSEFrame = (rawFrame) => {
+    if (typeof rawFrame !== 'string') return null
+
+    let event = null
+    let id = null
+    let retry = null
+    const dataLines = []
+    let hasField = false
+
+    for (const line of rawFrame.split(/\r?\n/)) {
+        if (!line || line.startsWith(':')) continue
+
+        const colonIndex = line.indexOf(':')
+        const field = colonIndex === -1 ? line : line.slice(0, colonIndex)
+        let value = colonIndex === -1 ? '' : line.slice(colonIndex + 1)
+        if (value.startsWith(' ')) value = value.slice(1)
+
+        if (field === 'data') {
+            dataLines.push(value)
+            hasField = true
+        } else if (field === 'event') {
+            event = value || null
+            hasField = true
+        } else if (field === 'id') {
+            id = value
+            hasField = true
+        } else if (field === 'retry') {
+            const parsedRetry = Number.parseInt(value, 10)
+            retry = Number.isFinite(parsedRetry) ? parsedRetry : null
+            hasField = true
+        }
+    }
+
+    if (!hasField) return null
+    return { event, data: dataLines.join('\n'), id, retry, raw: rawFrame }
+}
+
+/**
+ * 增量 SSE 解码器。TCP 分块可以落在 UTF-8 字符、字段名、JSON 或空行中的任意位置。
+ */
+class SSEDecoder {
+    constructor() {
+        this.decoder = new StringDecoder('utf8')
+        this.buffer = ''
+    }
+
+    /**
+     * @param {Buffer|string|Uint8Array} chunk
+     * @returns {Array<ReturnType<typeof parseSSEFrame>>}
+     */
+    push(chunk) {
+        if (chunk !== undefined && chunk !== null) {
+            this.buffer += typeof chunk === 'string'
+                ? chunk
+                : this.decoder.write(Buffer.from(chunk))
+        }
+        return this.#drain(false)
+    }
+
+    /**
+     * 冲刷 UTF-8 decoder，并按 SSE 规范分派 EOF 前尚未带空行的最后一个事件。
+     * @returns {Array<ReturnType<typeof parseSSEFrame>>}
+     */
+    end() {
+        this.buffer += this.decoder.end()
+        return this.#drain(true)
+    }
+
+    #drain(flush) {
+        const frames = []
+
+        while (this.buffer.length > 0) {
+            const boundary = this.buffer.match(/\r?\n\r?\n/)
+            if (!boundary || boundary.index === undefined) break
+
+            const rawFrame = this.buffer.slice(0, boundary.index)
+            this.buffer = this.buffer.slice(boundary.index + boundary[0].length)
+            const parsed = parseSSEFrame(rawFrame)
+            if (parsed) frames.push(parsed)
+        }
+
+        if (flush && this.buffer.trim()) {
+            const parsed = parseSSEFrame(this.buffer)
+            if (parsed) frames.push(parsed)
+            this.buffer = ''
+        }
+
+        return frames
+    }
+}
+
+/**
+ * 把解析后的事件重新编码为规范 SSE。用于安全透传，不依赖上游 TCP 分块方式。
+ * @param {{event?: string|null, data?: string, id?: string|null, retry?: number|null}} frame
+ * @returns {string}
+ */
+const formatSSEFrame = (frame = {}) => {
+    const lines = []
+    if (frame.event) lines.push(`event: ${frame.event}`)
+    if (frame.id !== null && frame.id !== undefined) lines.push(`id: ${frame.id}`)
+    if (frame.retry !== null && frame.retry !== undefined) lines.push(`retry: ${frame.retry}`)
+
+    const data = typeof frame.data === 'string' ? frame.data : String(frame.data ?? '')
+    for (const line of data.split('\n')) {
+        lines.push(`data: ${line}`)
+    }
+    return `${lines.join('\n')}\n\n`
+}
+
+/**
+ * 串行消费 Node readable 中的 SSE。for-await 会等待 onFrame，避免 end 事件越过异步 data handler。
+ * @param {AsyncIterable<Buffer|string>} stream
+ * @param {(frame: ReturnType<typeof parseSSEFrame>) => Promise<void>|void} onFrame
+ * @returns {Promise<{sawDone: boolean, eventCount: number}>}
+ */
+const consumeSSEStream = async (stream, onFrame) => {
+    if (!stream || typeof stream[Symbol.asyncIterator] !== 'function') {
+        throw new TypeError('上游响应不是可读取的异步流')
+    }
+
+    const decoder = new SSEDecoder()
+    let sawDone = false
+    let eventCount = 0
+
+    const consumeFrames = async (frames) => {
+        for (const frame of frames) {
+            eventCount += 1
+            if (frame.data.trim() === '[DONE]') sawDone = true
+            await onFrame(frame)
+        }
+    }
+
+    for await (const chunk of stream) {
+        await consumeFrames(decoder.push(chunk))
+    }
+    await consumeFrames(decoder.end())
+
+    return { sawDone, eventCount }
+}
+
+module.exports = {
+    SSEDecoder,
+    parseSSEFrame,
+    formatSSEFrame,
+    consumeSSEStream
+}

--- a/src/utils/tool-prompt.js
+++ b/src/utils/tool-prompt.js
@@ -13,6 +13,34 @@ const TOOL_CALL_OPEN = '<tool_call>';
  */
 const TOOL_CALL_CLOSE = '</tool_call>';
 
+const normalizeAllowedToolNames = (allowedToolNames) => {
+  if (!allowedToolNames) return null;
+  const names = allowedToolNames instanceof Set ? allowedToolNames : new Set(allowedToolNames);
+  return names.size > 0 ? names : null;
+};
+
+const serializeToolArguments = (args) => {
+  if (typeof args === 'string') {
+    try {
+      JSON.parse(args);
+      return args;
+    } catch (_) {
+      return JSON.stringify(args);
+    }
+  }
+  return JSON.stringify(args ?? {});
+};
+
+const createToolCallObject = (payload, index = 0, id = null) => ({
+  index,
+  id: id || `call_${generateUUID().replace(/-/g, '').slice(0, 24)}`,
+  type: 'function',
+  function: {
+    name: payload.name,
+    arguments: serializeToolArguments(payload.arguments)
+  }
+});
+
 /**
  * 将 JSON Schema 类型压缩为简短 TypeScript 风格签名
  * @param {Object} schema - JSON Schema 节点
@@ -226,31 +254,47 @@ const parseToolCallPayload = (raw) => {
 /**
  * 从完整文本中提取所有工具调用块
  * @param {string} fullText - 模型完整输出
- * @returns {{ cleanedText: string, toolCalls: Array<Object> }} 抽取结果
+ * @param {Object} [options]
+ * @param {Set<string>|Array<string>} [options.allowedToolNames]
+ * @returns {{ cleanedText: string, toolCalls: Array<Object>, errors: Array<Object> }} 抽取结果
  */
-const parseToolCallsFromText = (fullText) => {
+const parseToolCallsFromText = (fullText, options = {}) => {
   if (typeof fullText !== 'string' || !fullText.includes(TOOL_CALL_OPEN)) {
-    return { cleanedText: fullText || '', toolCalls: [] };
+    return { cleanedText: fullText || '', toolCalls: [], errors: [] };
   }
 
+  const allowedToolNames = normalizeAllowedToolNames(options.allowedToolNames);
   const toolCalls = [];
+  const errors = [];
   const pattern = /<tool_call>([\s\S]*?)<\/tool_call>/g;
   const cleanedText = fullText.replace(pattern, (_, inner) => {
     const payload = parseToolCallPayload(inner);
-    if (payload) {
-      toolCalls.push({
-        id: `call_${generateUUID().replace(/-/g, '').slice(0, 24)}`,
-        type: 'function',
-        function: {
-          name: payload.name,
-          arguments: JSON.stringify(payload.arguments ?? {})
-        }
-      });
+    if (!payload) {
+      errors.push({ type: 'invalid_json', raw: inner });
+    } else if (allowedToolNames && !allowedToolNames.has(payload.name)) {
+      errors.push({ type: 'unknown_tool', name: payload.name });
+    } else {
+      toolCalls.push(createToolCallObject(payload, toolCalls.length));
     }
     return '';
   });
 
-  return { cleanedText: cleanedText.trim(), toolCalls };
+  const unclosedIndex = cleanedText.indexOf(TOOL_CALL_OPEN);
+  let finalText = cleanedText;
+  if (unclosedIndex !== -1) {
+    const raw = cleanedText.slice(unclosedIndex + TOOL_CALL_OPEN.length);
+    const payload = parseToolCallPayload(raw);
+    if (!payload) {
+      errors.push({ type: 'truncated_tool_call', raw });
+    } else if (allowedToolNames && !allowedToolNames.has(payload.name)) {
+      errors.push({ type: 'unknown_tool', name: payload.name });
+    } else {
+      toolCalls.push(createToolCallObject(payload, toolCalls.length));
+    }
+    finalText = cleanedText.slice(0, unclosedIndex);
+  }
+
+  return { cleanedText: finalText.trim(), toolCalls, errors };
 };
 
 /**
@@ -264,11 +308,26 @@ const parseToolCallsFromText = (fullText) => {
  *   hasEmittedAnyCall: () => boolean
  * }} 解析器实例
  */
-const createToolCallStreamParser = () => {
+const createToolCallStreamParser = (options = {}) => {
+  const allowedToolNames = normalizeAllowedToolNames(options.allowedToolNames);
   let pendingText = '';
   let inToolCall = false;
   let toolCallBuffer = '';
   let emittedCallCount = 0;
+  const errors = [];
+
+  const acceptPayload = (payload, raw, result) => {
+    if (!payload) {
+      errors.push({ type: 'invalid_json', raw });
+      return;
+    }
+    if (allowedToolNames && !allowedToolNames.has(payload.name)) {
+      errors.push({ type: 'unknown_tool', name: payload.name });
+      return;
+    }
+    result.completedCalls.push(createToolCallObject(payload, emittedCallCount));
+    emittedCallCount += 1;
+  };
 
   /**
    * 在等待标签出现时，安全地输出已确定不是标签前缀的部分
@@ -308,18 +367,7 @@ const createToolCallStreamParser = () => {
         buffer = toolCallBuffer.slice(closeIdx + TOOL_CALL_CLOSE.length);
         toolCallBuffer = '';
         const payload = parseToolCallPayload(inner);
-        if (payload) {
-          result.completedCalls.push({
-            index: emittedCallCount,
-            id: `call_${generateUUID().replace(/-/g, '').slice(0, 24)}`,
-            type: 'function',
-            function: {
-              name: payload.name,
-              arguments: JSON.stringify(payload.arguments ?? {})
-            }
-          });
-          emittedCallCount += 1;
-        }
+        acceptPayload(payload, inner, result);
         inToolCall = false;
         continue;
       }
@@ -350,18 +398,7 @@ const createToolCallStreamParser = () => {
     const result = { textDelta: '', completedCalls: [] };
     if (inToolCall && toolCallBuffer) {
       const payload = parseToolCallPayload(toolCallBuffer);
-      if (payload) {
-        result.completedCalls.push({
-          index: emittedCallCount,
-          id: `call_${generateUUID().replace(/-/g, '').slice(0, 24)}`,
-          type: 'function',
-          function: {
-            name: payload.name,
-            arguments: JSON.stringify(payload.arguments ?? {})
-          }
-        });
-        emittedCallCount += 1;
-      }
+      acceptPayload(payload, toolCallBuffer, result);
       toolCallBuffer = '';
       inToolCall = false;
     }
@@ -376,7 +413,86 @@ const createToolCallStreamParser = () => {
     push,
     flush,
     hasPendingCall: () => inToolCall,
-    hasEmittedAnyCall: () => emittedCallCount > 0
+    hasEmittedAnyCall: () => emittedCallCount > 0,
+    hasParseError: () => errors.length > 0,
+    getErrors: () => [...errors]
+  };
+};
+
+/**
+ * 累积 OpenAI 原生 delta.tool_calls。网页上游一旦开始原生返回工具调用，桥接层无需再依赖 XML。
+ */
+const createNativeToolCallAccumulator = (options = {}) => {
+  const allowedToolNames = normalizeAllowedToolNames(options.allowedToolNames);
+  const calls = new Map();
+  const errors = [];
+
+  const push = (deltas) => {
+    if (!Array.isArray(deltas)) return;
+    for (const delta of deltas) {
+      if (!delta || typeof delta !== 'object') continue;
+      const index = Number.isInteger(delta.index) ? delta.index : calls.size;
+      const current = calls.get(index) || {
+        index,
+        id: delta.id || null,
+        type: delta.type || 'function',
+        function: { name: '', arguments: '' }
+      };
+      if (delta.id) current.id = delta.id;
+      if (delta.type) current.type = delta.type;
+      if (typeof delta.function?.name === 'string' && delta.function.name) {
+        const incomingName = delta.function.name;
+        if (!current.function.name) {
+          current.function.name = incomingName;
+        } else if (incomingName === current.function.name || current.function.name.endsWith(incomingName)) {
+          // 某些兼容上游会在每个 delta 重复完整 name，不能重复拼接。
+        } else if (incomingName.startsWith(current.function.name)) {
+          current.function.name = incomingName;
+        } else {
+          current.function.name += incomingName;
+        }
+      }
+      if (typeof delta.function?.arguments === 'string') current.function.arguments += delta.function.arguments;
+      calls.set(index, current);
+    }
+  };
+
+  const finalize = () => {
+    const finalized = [];
+    for (const [index, call] of [...calls.entries()].sort((a, b) => a[0] - b[0])) {
+      if (!call.function.name) {
+        errors.push({ type: 'missing_tool_name', index });
+        continue;
+      }
+      if (allowedToolNames && !allowedToolNames.has(call.function.name)) {
+        errors.push({ type: 'unknown_tool', name: call.function.name });
+        continue;
+      }
+      try {
+        JSON.parse(call.function.arguments || '{}');
+      } catch (_) {
+        errors.push({ type: 'invalid_arguments', name: call.function.name });
+        continue;
+      }
+      finalized.push({
+        index: finalized.length,
+        id: call.id || `call_${generateUUID().replace(/-/g, '').slice(0, 24)}`,
+        type: 'function',
+        function: {
+          name: call.function.name,
+          arguments: call.function.arguments || '{}'
+        }
+      });
+    }
+    return finalized;
+  };
+
+  return {
+    push,
+    finalize,
+    hasAny: () => calls.size > 0,
+    hasParseError: () => errors.length > 0,
+    getErrors: () => [...errors]
   };
 };
 
@@ -386,5 +502,7 @@ module.exports = {
   buildToolSystemPrompt,
   foldToolMessages,
   parseToolCallsFromText,
-  createToolCallStreamParser
+  createToolCallStreamParser,
+  createNativeToolCallAccumulator,
+  serializeToolArguments
 };

--- a/tests/agent-protocol.test.js
+++ b/tests/agent-protocol.test.js
@@ -1,0 +1,202 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { Readable } = require('node:stream')
+
+process.env.API_KEY = process.env.API_KEY || 'test-only-key'
+
+const { createUpstreamDeltaNormalizer, formatHistoryMessages } = require('../src/utils/chat-helpers.js')
+const {
+  normalizeOpenAIFinishReason,
+  handleStreamResponse,
+  handleNonStreamResponse
+} = require('../src/controllers/chat.js')
+const {
+  mapAnthropicStopReason,
+  handleAnthropicStream,
+  handleAnthropicNonStream
+} = require('../src/controllers/anthropic.js')
+
+test.after(() => {
+  require('../src/utils/account.js').destroy()
+})
+
+const createMockResponse = () => ({
+  output: '',
+  headers: {},
+  headersSent: false,
+  writableEnded: false,
+  statusCode: 200,
+  set(headers) {
+    Object.assign(this.headers, headers)
+    return this
+  },
+  setHeader(name, value) {
+    this.headers[name] = value
+  },
+  write(chunk) {
+    this.headersSent = true
+    this.output += String(chunk)
+    return true
+  },
+  end(chunk = '') {
+    if (chunk) this.write(chunk)
+    this.writableEnded = true
+  },
+  status(code) {
+    this.statusCode = code
+    return this
+  },
+  json(value) {
+    this.headersSent = true
+    this.output += JSON.stringify(value)
+    this.writableEnded = true
+    return this
+  }
+})
+
+test('phase-less answer content is not silently discarded', () => {
+  const normalize = createUpstreamDeltaNormalizer()
+  assert.deepEqual(normalize({ content: 'final answer' }), {
+    phase: 'answer',
+    content: 'final answer'
+  })
+  assert.deepEqual(normalize({ reasoning_content: 'thinking' }), {
+    phase: 'think',
+    content: 'thinking'
+  })
+})
+
+test('finish reasons preserve truncation instead of reporting normal completion', () => {
+  assert.equal(normalizeOpenAIFinishReason('length', false, true), 'length')
+  assert.equal(normalizeOpenAIFinishReason(null, false, false), null)
+  assert.equal(mapAnthropicStopReason('length', false, true), 'max_tokens')
+  assert.equal(mapAnthropicStopReason(null, false, false), null)
+  assert.equal(mapAnthropicStopReason('stop', true, true), 'tool_use')
+})
+
+test('history envelope preserves role and punctuation with JSONL', () => {
+  const history = formatHistoryMessages([
+    { role: 'system', content: 'keep: semicolons; intact' },
+    { role: 'assistant', content: 'done; not really' }
+  ])
+  const lines = history.split('\n').map(line => JSON.parse(line))
+  assert.deepEqual(lines, [
+    { role: 'system', content: 'keep: semicolons; intact' },
+    { role: 'assistant', content: 'done; not really' }
+  ])
+})
+
+test('controller modules can consume fragmented terminal frames', async () => {
+  const chunks = [
+    Buffer.from('data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"len'),
+    Buffer.from('gth"}]}\r\n\r\ndata: [DO'),
+    Buffer.from('NE]\r\n\r\n')
+  ]
+  const { consumeUpstream } = require('../src/controllers/anthropic.js')
+  const seen = []
+  const result = await consumeUpstream(Readable.from(chunks), json => seen.push(json))
+  assert.equal(seen.length, 1)
+  assert.equal(seen[0].choices[0].finish_reason, 'length')
+  assert.equal(result.sawDone, true)
+})
+
+test('OpenAI stream propagates length and rejects incomplete EOF', async () => {
+  const completedRes = createMockResponse()
+  await handleStreamResponse(
+    completedRes,
+    Readable.from([
+      'data: {"choices":[{"delta":{"content":"partial answer"},"finish_reason":null}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"length"}]}\n\ndata: [DONE]\n\n'
+    ]),
+    false,
+    false,
+    { messages: [] },
+    {}
+  )
+  assert.match(completedRes.output, /"finish_reason":"length"/)
+  assert.doesNotMatch(completedRes.output, /"finish_reason":"stop"/)
+
+  const incompleteRes = createMockResponse()
+  await handleStreamResponse(
+    incompleteRes,
+    Readable.from(['data: {"choices":[{"delta":{"content":"cut"},"finish_reason":null}]}\n\n']),
+    false,
+    false,
+    { messages: [] },
+    {}
+  )
+  assert.match(incompleteRes.output, /"code":"upstream_incomplete"/)
+  assert.doesNotMatch(incompleteRes.output, /"finish_reason":"stop"/)
+})
+
+test('Anthropic stream emits thinking signature, max_tokens and tool parse errors', async () => {
+  const thinkingRes = createMockResponse()
+  await handleAnthropicStream(
+    thinkingRes,
+    {
+      message_id: 'msg_test',
+      model: 'qwen-test',
+      hasTools: false,
+      requestBody: { messages: [] }
+    },
+    Readable.from([
+      'data: {"choices":[{"delta":{"phase":"think","content":"reason"},"finish_reason":null}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"length"}]}\n\ndata: [DONE]\n\n'
+    ])
+  )
+  assert.match(thinkingRes.output, /"type":"signature_delta"/)
+  assert.match(thinkingRes.output, /"stop_reason":"max_tokens"/)
+  assert.match(thinkingRes.output, /event: message_stop/)
+
+  const invalidToolRes = createMockResponse()
+  await handleAnthropicStream(
+    invalidToolRes,
+    {
+      message_id: 'msg_tool',
+      model: 'qwen-test',
+      hasTools: true,
+      toolChoice: 'auto',
+      allowedToolNames: ['read_file'],
+      requestBody: { messages: [] }
+    },
+    Readable.from([
+      'data: {"choices":[{"delta":{"phase":"answer","content":"<tool_call>{\\"name\\":\\"read_file\\",\\"arguments\\":{\\"path\\":\\""},"finish_reason":null}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n'
+    ])
+  )
+  assert.match(invalidToolRes.output, /event: error/)
+  assert.match(invalidToolRes.output, /invalid_tool_call_error/)
+  assert.doesNotMatch(invalidToolRes.output, /event: message_stop/)
+})
+
+test('non-stream responses preserve truncation for both protocols', async () => {
+  const frames = [
+    'data: {"choices":[{"delta":{"content":"partial"},"finish_reason":null}]}\n\n',
+    'data: {"choices":[{"delta":{},"finish_reason":"length"}]}\n\ndata: [DONE]\n\n'
+  ]
+
+  const openAIRes = createMockResponse()
+  await handleNonStreamResponse(
+    openAIRes,
+    Readable.from(frames),
+    false,
+    false,
+    'qwen-test',
+    { messages: [] },
+    {}
+  )
+  assert.match(openAIRes.output, /"finish_reason":"length"/)
+
+  const anthropicRes = createMockResponse()
+  await handleAnthropicNonStream(
+    anthropicRes,
+    {
+      message_id: 'msg_nonstream',
+      model: 'qwen-test',
+      hasTools: false,
+      requestBody: { messages: [] }
+    },
+    Readable.from(frames)
+  )
+  assert.match(anthropicRes.output, /"stop_reason":"max_tokens"/)
+})

--- a/tests/sse.test.js
+++ b/tests/sse.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { PassThrough, Readable } = require('node:stream')
+
+const {
+  SSEDecoder,
+  consumeSSEStream,
+  formatSSEFrame
+} = require('../src/utils/sse.js')
+
+test('SSEDecoder handles arbitrary TCP, UTF-8 and CRLF boundaries', () => {
+  const decoder = new SSEDecoder()
+  const wire = Buffer.from(
+    'event: content\r\ndata: {"text":"你好"}\r\n\r\n' +
+    'data: first\ndata: second\n\n' +
+    'data: [DONE]\n\n'
+  )
+  const frames = []
+  for (let i = 0; i < wire.length; i += 3) {
+    frames.push(...decoder.push(wire.subarray(i, i + 3)))
+  }
+  frames.push(...decoder.end())
+
+  assert.equal(frames.length, 3)
+  assert.equal(frames[0].event, 'content')
+  assert.equal(frames[0].data, '{"text":"你好"}')
+  assert.equal(frames[1].data, 'first\nsecond')
+  assert.equal(frames[2].data, '[DONE]')
+})
+
+test('SSEDecoder dispatches the final event even without a trailing blank line', () => {
+  const decoder = new SSEDecoder()
+  assert.deepEqual(decoder.push('data: {"ok":true}'), [])
+  const frames = decoder.end()
+  assert.equal(frames.length, 1)
+  assert.equal(frames[0].data, '{"ok":true}')
+})
+
+test('consumeSSEStream serializes async handlers before resolving', async () => {
+  const stream = new PassThrough()
+  const seen = []
+  const consuming = consumeSSEStream(stream, async frame => {
+    await new Promise(resolve => setTimeout(resolve, 10))
+    seen.push(frame.data)
+  })
+
+  stream.end('data: one\n\ndata: two\n\ndata: [DONE]\n\n')
+  const result = await consuming
+
+  assert.deepEqual(seen, ['one', 'two', '[DONE]'])
+  assert.equal(result.sawDone, true)
+  assert.equal(result.eventCount, 3)
+})
+
+test('formatSSEFrame produces a frame that survives byte-by-byte decoding', async () => {
+  const encoded = formatSSEFrame({ event: 'message', data: '第一行\n第二行', id: '42' })
+  const frames = []
+  await consumeSSEStream(Readable.from([...Buffer.from(encoded)].map(byte => Buffer.from([byte]))), frame => {
+    frames.push(frame)
+  })
+  assert.equal(frames[0].event, 'message')
+  assert.equal(frames[0].id, '42')
+  assert.equal(frames[0].data, '第一行\n第二行')
+})

--- a/tests/tool-prompt.test.js
+++ b/tests/tool-prompt.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  parseToolCallsFromText,
+  createToolCallStreamParser,
+  createNativeToolCallAccumulator
+} = require('../src/utils/tool-prompt.js')
+
+test('stream parser accepts split valid calls and preserves JSON string arguments', () => {
+  const parser = createToolCallStreamParser({ allowedToolNames: ['read_file'] })
+  const first = parser.push('before<tool_')
+  const second = parser.push('call>{"name":"read_file","arguments":"{\\"path\\":\\"a\\"}"}</tool_call>')
+  const tail = parser.flush()
+
+  assert.equal(first.textDelta, 'before')
+  assert.equal(second.completedCalls.length, 1)
+  assert.equal(second.completedCalls[0].function.arguments, '{"path":"a"}')
+  assert.equal(tail.textDelta, '')
+  assert.equal(parser.hasParseError(), false)
+})
+
+test('truncated and unknown tool calls become explicit parser errors', () => {
+  const truncated = createToolCallStreamParser({ allowedToolNames: ['read_file'] })
+  truncated.push('<tool_call>{"name":"read_file","arguments":{"path":"a')
+  truncated.flush()
+  assert.equal(truncated.hasEmittedAnyCall(), false)
+  assert.equal(truncated.hasParseError(), true)
+
+  const unknown = parseToolCallsFromText(
+    '<tool_call>{"name":"missing","arguments":{}}</tool_call>',
+    { allowedToolNames: ['read_file'] }
+  )
+  assert.equal(unknown.toolCalls.length, 0)
+  assert.equal(unknown.errors[0].type, 'unknown_tool')
+})
+
+test('native tool accumulator rebuilds fragmented OpenAI tool deltas', () => {
+  const accumulator = createNativeToolCallAccumulator({ allowedToolNames: ['read_file'] })
+  accumulator.push([{ index: 0, id: 'call_1', type: 'function', function: { name: 'read_file', arguments: '' } }])
+  accumulator.push([{ index: 0, function: { arguments: '{"path":' } }])
+  accumulator.push([{ index: 0, function: { arguments: '"a"}' } }])
+
+  const calls = accumulator.finalize()
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].id, 'call_1')
+  assert.equal(calls[0].function.arguments, '{"path":"a"}')
+  assert.equal(accumulator.hasParseError(), false)
+})


### PR DESCRIPTION
## 背景

Agent 客户端通过 `/v1/messages`、`/v1/chat/completions` 或 CLI 端点运行长任务时，上游截断、异常 EOF、SSE 跨 TCP 分块或残缺工具调用会被桥接层包装成正常的 `stop` / `end_turn`，导致客户端把未完成任务误判为完成。

## 主要修改

- 新增统一增量 SSE 解码器，支持任意 TCP、UTF-8、LF/CRLF 分块，并串行等待异步 frame handler
- OpenAI/Anthropic 端点保留上游真实结束原因，正确映射 `length` / `max_tokens`
- 上游未发送终止标记或传输异常时返回明确协议错误，不再伪造正常完成
- 修复 CLI 端点按 TCP chunk 拆分并转发残缺 JSON 的问题，并将请求超时提升到 10 分钟
- 同时支持 prompt/XML 和原生 `delta.tool_calls`，校验工具名及参数完整性
- 残缺、非法或未知工具调用返回显式错误，`tool_choice=required` 重试提示写入真实当前消息
- Anthropic thinking 流补齐 `signature_delta`，非流式 thinking block 补齐 signature
- 对无 `phase` 的正文回退为 answer，避免 Thinking/Max 模型只显示思考而丢失最终答案
- 多轮历史从易冲突的分号拼接改为 JSONL 信封，保留角色、换行和标点边界

## 验证

运行：

```bash
node --test tests/*.test.js
```

结果：23 项测试全部通过。新增测试覆盖：

- SSE 逐字节、UTF-8、CRLF 和无尾随空行分块
- 异步 frame handler 的结束竞态
- OpenAI/Anthropic 流式与非流式截断原因传播
- 异常 EOF 不再返回正常 stop/end_turn
- Anthropic thinking 签名事件
- 工具调用跨分块、截断、未知工具及原生 delta 累积
- 多轮上下文 JSONL 边界保真

当前测试环境没有真实 Qwen 账户，因此未执行真实账号的上游端到端请求；控制器级流式测试已覆盖原故障路径。