### PR TITLE
fix(data): 原子写入 data.json，避免并发保存把文件写坏

### DIFF
--- a/src/controllers/anthropic.js
+++ b/src/controllers/anthropic.js
@@ -725,7 +725,7 @@ const handleAnthropicMessages = async (req, res) => {
     if (!upstreamResp.status || !upstreamResp.response) {
       return res.status(500).json({
         type: 'error',
-        error: { type: 'api_error', message: 'Request failed' }
+        error: { type: 'api_error', message: upstreamResp.message || 'Request failed' }
       });
     }
 

--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -783,7 +783,7 @@ const handleChatCompletion = async (req, res) => {
         if (!response_data.status || !response_data.response) {
             res.status(500)
                 .json({
-                    error: "Request failed"
+                    error: response_data.message || "Request failed"
                 })
             return
         }

--- a/src/utils/account.js
+++ b/src/utils/account.js
@@ -87,6 +87,8 @@ class Account {
         // 账户数据
         this.accountTokens = []
         this.isInitialized = false
+        // 初始化失败的原因（例如 data.json 损坏），用于给客户端返回可读的错误
+        this.initError = null
 
         // 配置信息
         this.defaultHeaders = config.defaultHeaders || {}
@@ -117,11 +119,30 @@ class Account {
             }
 
             this.isInitialized = true
+            this.initError = null
             logger.success(`账户管理器初始化完成，共加载 ${this.accountTokens.length} 个账户`, 'ACCOUNT')
         } catch (error) {
             this.isInitialized = false
+            this.initError = error
             logger.error('账户管理器初始化失败', 'ACCOUNT', '', error)
         }
+    }
+
+    /**
+     * 账户不可用的原因——供上层把「Request failed」换成人能看懂的说明
+     * @returns {string|null} 不可用原因；null 表示账户可用
+     */
+    getUnavailableReason() {
+        if (this.initError) {
+            return `账户管理器初始化失败：${this.initError.message}`
+        }
+        if (!this.isInitialized) {
+            return '账户管理器尚未初始化完成，请稍后重试'
+        }
+        if (!Array.isArray(this.accountTokens) || this.accountTokens.length === 0) {
+            return '没有可用的账户，请在管理面板中添加账户'
+        }
+        return null
     }
 
     /**

--- a/src/utils/data-persistence.js
+++ b/src/utils/data-persistence.js
@@ -10,10 +10,39 @@ const { logger } = require('./logger')
  */
 // Debounce 窗口（per-email）写入 stats——避免每次 token 累计都触发文件 I/O
 const STATS_PERSIST_DEBOUNCE_MS = 5000
+// 备份（data.json.bak）最小刷新间隔——不必每次落盘都多写一份
+const BACKUP_MIN_INTERVAL_MS = 5 * 60 * 1000
+// rename 重试间隔：Windows / 网络盘上目标文件被占用时可能短暂 EPERM / EBUSY
+const RENAME_RETRY_DELAYS_MS = [20, 50, 100]
+
+// 进程内串行化：所有对 data.json 的 read-modify-write 排队执行。
+// 队列必须是模块级的——进程里存在多个 DataPersistence 实例
+// （utils/account.js 一个、routes/settings.js 一个），实例级的锁挡不住并发。
+// 注：PM2 cluster（PM2_INSTANCES > 1）下跨进程仍可能「后写覆盖先写」丢一次统计，
+// 但原子 rename 保证任何时刻文件都是完整 JSON，不会再出现半截内容。
+let fileWriteQueue = Promise.resolve()
+let tmpFileCounter = 0
+let lastBackupAt = 0
+
+/**
+ * 把一次文件读写排入串行队列
+ * @param {Function} task - 返回 Promise 的任务
+ * @returns {Promise<*>} 任务结果
+ */
+const enqueueFileTask = (task) => {
+  const result = fileWriteQueue.then(task, task)
+  // 队列本身不能因为单次失败而中断
+  fileWriteQueue = result.then(() => { }, () => { })
+  return result
+}
+
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 
 class DataPersistence {
   constructor() {
     this.dataFilePath = path.join(__dirname, '../../data/data.json')
+    // 最近一次「解析成功」的快照，用于文件损坏时自愈
+    this.backupFilePath = `${this.dataFilePath}.bak`
     // 每个 email 的待持久化 stats 与定时器（debounce）
     this._statsPersistTimers = new Map()
     this._statsPendingPayload = new Map()
@@ -118,19 +147,19 @@ class DataPersistence {
   }
 
   async _loadSettingsFromFile() {
-    await this._ensureDataFileExists()
-    const fileContent = await fs.readFile(this.dataFilePath, 'utf-8')
-    const data = JSON.parse(fileContent)
-    return (data.settings && typeof data.settings === 'object') ? data.settings : {}
+    return enqueueFileTask(async () => {
+      const data = await this._readDataFile()
+      return (data.settings && typeof data.settings === 'object') ? data.settings : {}
+    })
   }
 
   async _saveSettingsToFile(partial) {
-    await this._ensureDataFileExists()
-    const fileContent = await fs.readFile(this.dataFilePath, 'utf-8')
-    const data = JSON.parse(fileContent)
-    data.settings = { ...(data.settings || {}), ...partial }
-    await fs.writeFile(this.dataFilePath, JSON.stringify(data, null, 2), 'utf-8')
-    return true
+    return enqueueFileTask(async () => {
+      const data = await this._readDataFile()
+      data.settings = { ...(data.settings || {}), ...partial }
+      await this._writeDataFile(data)
+      return true
+    })
   }
 
   /**
@@ -172,13 +201,10 @@ class DataPersistence {
    * @private
    */
   async _loadFromFile() {
-    // 确保文件存在
-    await this._ensureDataFileExists()
-    
-    const fileContent = await fs.readFile(this.dataFilePath, 'utf-8')
-    const data = JSON.parse(fileContent)
-    
-    return data.accounts || []
+    return enqueueFileTask(async () => {
+      const data = await this._readDataFile()
+      return data.accounts || []
+    })
   }
 
   /**
@@ -220,36 +246,35 @@ class DataPersistence {
    * @private
    */
   async _saveToFile(email, accountData) {
-    await this._ensureDataFileExists()
+    return enqueueFileTask(async () => {
+      const data = await this._readDataFile()
 
-    const fileContent = await fs.readFile(this.dataFilePath, 'utf-8')
-    const data = JSON.parse(fileContent)
+      if (!data.accounts) {
+        data.accounts = []
+      }
 
-    if (!data.accounts) {
-      data.accounts = []
-    }
+      const existingIndex = data.accounts.findIndex(account => account.email === email)
+      const existing = existingIndex !== -1 ? data.accounts[existingIndex] : {}
 
-    const existingIndex = data.accounts.findIndex(account => account.email === email)
-    const existing = existingIndex !== -1 ? data.accounts[existingIndex] : {}
+      // 仅写入显式传入的字段；未传字段保留 existing 值。stats 同理——
+      // 避免 token refresh / proxy update 的 partial save 把累计 stats 清零
+      const merged = { ...existing, email }
+      if (accountData.password !== undefined) merged.password = accountData.password
+      if (accountData.token !== undefined) merged.token = accountData.token
+      if (accountData.expires !== undefined) merged.expires = accountData.expires
+      if (accountData.proxy !== undefined) merged.proxy = accountData.proxy ?? null
+      if (accountData.stats !== undefined) merged.stats = accountData.stats
+      if (accountData.statsHistory !== undefined) merged.statsHistory = accountData.statsHistory
 
-    // 仅写入显式传入的字段；未传字段保留 existing 值。stats 同理——
-    // 避免 token refresh / proxy update 的 partial save 把累计 stats 清零
-    const merged = { ...existing, email }
-    if (accountData.password !== undefined) merged.password = accountData.password
-    if (accountData.token !== undefined) merged.token = accountData.token
-    if (accountData.expires !== undefined) merged.expires = accountData.expires
-    if (accountData.proxy !== undefined) merged.proxy = accountData.proxy ?? null
-    if (accountData.stats !== undefined) merged.stats = accountData.stats
-    if (accountData.statsHistory !== undefined) merged.statsHistory = accountData.statsHistory
+      if (existingIndex !== -1) {
+        data.accounts[existingIndex] = merged
+      } else {
+        data.accounts.push(merged)
+      }
 
-    if (existingIndex !== -1) {
-      data.accounts[existingIndex] = merged
-    } else {
-      data.accounts.push(merged)
-    }
-
-    await fs.writeFile(this.dataFilePath, JSON.stringify(data, null, 2), 'utf-8')
-    return true
+      await this._writeDataFile(data)
+      return true
+    })
   }
 
   /**
@@ -270,23 +295,22 @@ class DataPersistence {
    * @private
    */
   async _saveAllToFile(accounts) {
-    await this._ensureDataFileExists()
-    
-    const fileContent = await fs.readFile(this.dataFilePath, 'utf-8')
-    const data = JSON.parse(fileContent)
-    
-    data.accounts = accounts.map(account => ({
-      email: account.email,
-      password: account.password,
-      token: account.token,
-      expires: account.expires,
-      proxy: account.proxy ?? null,
-      stats: account.stats ?? undefined,
-      statsHistory: account.statsHistory ?? undefined
-    }))
+    return enqueueFileTask(async () => {
+      const data = await this._readDataFile()
 
-    await fs.writeFile(this.dataFilePath, JSON.stringify(data, null, 2), 'utf-8')
-    return true
+      data.accounts = accounts.map(account => ({
+        email: account.email,
+        password: account.password,
+        token: account.token,
+        expires: account.expires,
+        proxy: account.proxy ?? null,
+        stats: account.stats ?? undefined,
+        statsHistory: account.statsHistory ?? undefined
+      }))
+
+      await this._writeDataFile(data)
+      return true
+    })
   }
 
   /**
@@ -327,6 +351,166 @@ class DataPersistence {
   }
 
   /**
+   * 读取并解析 data.json；解析失败时尝试用备份自愈
+   * 仅在 enqueueFileTask 内部调用——保证 read-modify-write 不交错
+   * @returns {Promise<Object>} 解析后的数据对象
+   * @private
+   */
+  async _readDataFile() {
+    await this._ensureDataFileExists()
+
+    const fileContent = await fs.readFile(this.dataFilePath, 'utf-8')
+    let data
+    try {
+      data = JSON.parse(fileContent)
+    } catch (parseError) {
+      return await this._recoverFromBackup(parseError, fileContent.length)
+    }
+
+    // 解析成功即为「已知良好」，按最小间隔刷新备份
+    await this._refreshBackup(fileContent, data)
+    return data
+  }
+
+  /**
+   * data.json 损坏时的恢复：优先用备份，没有备份就大声报错并中止
+   * 绝不能静默返回空账户列表——那会让服务带着 0 个账户启动，
+   * 之后所有请求都以「无可用令牌」失败，并且下一次写入会把损坏文件覆盖掉
+   * @param {Error} parseError - JSON.parse 抛出的错误
+   * @param {number} brokenSize - 损坏文件的字符数（便于排查）
+   * @returns {Promise<Object>} 从备份恢复的数据对象
+   * @private
+   */
+  async _recoverFromBackup(parseError, brokenSize) {
+    logger.error(
+      `数据文件损坏: ${this.dataFilePath} (${brokenSize} 字符) — ${parseError.message}`,
+      'DATA'
+    )
+
+    let backupContent = null
+    let backupData = null
+    try {
+      backupContent = await fs.readFile(this.backupFilePath, 'utf-8')
+      backupData = JSON.parse(backupContent)
+    } catch (backupError) {
+      backupData = null
+    }
+
+    if (!backupData || typeof backupData !== 'object') {
+      logger.error(
+        `备份不可用 (${this.backupFilePath})，账户数据无法自动恢复；` +
+        '损坏文件已原样保留，请人工修复后重启服务',
+        'DATA'
+      )
+      throw new Error(`数据文件 ${this.dataFilePath} 损坏且无可用备份: ${parseError.message}`)
+    }
+
+    // 先给损坏文件留证（copy 而非 rename——避免中途崩溃导致 data.json 缺失），再用备份覆盖
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+    const quarantinePath = `${this.dataFilePath}.corrupt-${stamp}`
+    try {
+      await fs.copyFile(this.dataFilePath, quarantinePath)
+    } catch (copyError) {
+      logger.warn(`损坏文件留证失败: ${quarantinePath}`, 'DATA', '', copyError)
+    }
+
+    await this._writeFileAtomic(this.dataFilePath, backupContent)
+    logger.warn(
+      `已用备份恢复数据文件（${(backupData.accounts || []).length} 个账户）；` +
+      `损坏副本: ${quarantinePath}`,
+      'DATA'
+    )
+    return backupData
+  }
+
+  /**
+   * 写入 data.json 并刷新备份
+   * @param {Object} data - 完整数据对象
+   * @private
+   */
+  async _writeDataFile(data) {
+    const content = JSON.stringify(data, null, 2)
+    await this._writeFileAtomic(this.dataFilePath, content)
+    await this._refreshBackup(content, data)
+  }
+
+  /**
+   * 原子写入：先写同目录临时文件 + fsync，再 rename 覆盖目标
+   * rename 在同一文件系统内是原子的——读取方永远看到完整文件；
+   * 中途崩溃也只会留下临时文件，目标文件保持上一版完整内容
+   * @param {string} targetPath - 目标文件路径
+   * @param {string} content - 文件内容
+   * @private
+   */
+  async _writeFileAtomic(targetPath, content) {
+    const tmpPath = `${targetPath}.${process.pid}.${++tmpFileCounter}.tmp`
+    let handle = null
+    try {
+      handle = await fs.open(tmpPath, 'w')
+      await handle.writeFile(content, 'utf-8')
+      // fsync：保证 rename 之后内容确实落盘（掉电 / 容器被杀时才不会拿到空文件）
+      await handle.sync()
+      await handle.close()
+      handle = null
+
+      await this._renameWithRetry(tmpPath, targetPath)
+    } catch (error) {
+      if (handle) {
+        try { await handle.close() } catch (closeError) { /* 已经失败，忽略 */ }
+      }
+      try { await fs.unlink(tmpPath) } catch (unlinkError) { /* 临时文件可能不存在 */ }
+      throw error
+    }
+  }
+
+  /**
+   * rename 重试：目标文件被杀毒软件 / 另一进程短暂占用时不至于直接失败
+   * @param {string} fromPath - 临时文件路径
+   * @param {string} toPath - 目标文件路径
+   * @private
+   */
+  async _renameWithRetry(fromPath, toPath) {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await fs.rename(fromPath, toPath)
+        return
+      } catch (error) {
+        const retriable = error.code === 'EPERM' || error.code === 'EACCES' || error.code === 'EBUSY'
+        if (!retriable || attempt >= RENAME_RETRY_DELAYS_MS.length) {
+          throw error
+        }
+        await sleep(RENAME_RETRY_DELAYS_MS[attempt])
+      }
+    }
+  }
+
+  /**
+   * 刷新备份文件（限流；失败不影响主流程）
+   * @param {string} content - 已确认可解析的内容
+   * @param {Object} data - 与 content 对应的数据对象
+   * @private
+   */
+  async _refreshBackup(content, data) {
+    // 空账户列表不值得做备份，更不能拿它覆盖已有备份：
+    // data.json 被误删时会先生成空的默认文件，备份必须留住上一份真实数据
+    if (!data || !Array.isArray(data.accounts) || data.accounts.length === 0) {
+      return
+    }
+
+    const now = Date.now()
+    if (now - lastBackupAt < BACKUP_MIN_INTERVAL_MS) {
+      return
+    }
+    lastBackupAt = now
+
+    try {
+      await this._writeFileAtomic(this.backupFilePath, content)
+    } catch (error) {
+      logger.warn('备份文件写入失败（不影响主数据文件）', 'DATA', '', error)
+    }
+  }
+
+  /**
    * 确保数据文件存在
    * @private
    */
@@ -347,7 +531,7 @@ class DataPersistence {
         accounts: []
       }
 
-      await fs.writeFile(this.dataFilePath, JSON.stringify(defaultData, null, 2), 'utf-8')
+      await this._writeFileAtomic(this.dataFilePath, JSON.stringify(defaultData, null, 2))
       logger.success('默认数据文件创建成功', 'FILE')
     }
   }

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -37,10 +37,14 @@ const sendChatRequest = async (body) => {
     const currentToken = currentAccount ? currentAccount.token : null
 
     if (!currentToken) {
-        logger.error('无法获取有效的访问令牌', 'TOKEN')
+        // 把具体原因（data.json 损坏 / 尚未初始化 / 没有账户）透传给客户端，
+        // 否则调用方只能看到笼统的「Request failed」，排查要靠翻服务端日志
+        const reason = accountManager.getUnavailableReason() || '无法获取有效的访问令牌'
+        logger.error(reason, 'TOKEN')
         return {
             status: false,
-            response: null
+            response: null,
+            message: reason
         }
     }
 


### PR DESCRIPTION
## 问题

`DataPersistence._saveToFile` 的流程是「读全文 → `JSON.parse` → 改一条 → `fs.writeFile` 覆盖」，既没有临时文件，也没有队列。

`saveAccountStats` 为每个账户单独挂 5 秒 debounce 定时器，多个账户的定时器很容易落在同一刻；`routes/settings.js` 还持有另一个 `DataPersistence` 实例。两次 read-modify-write 交错时：

- `fs.writeFile` 以 `'w'` 打开，先把文件截断为 0；
- 较短的一次写入盖不住上一次的尾部，文件末尾多出一个 `}`。

之后每次保存都在 `JSON.parse` 处失败（日志里成百上千条），但进程还活着、账户还在内存里，服务看起来一切正常。直到重启：`loadAccounts` 抛异常 → `accountTokens = []` → `isInitialized = false` → 所有请求返回 `{"error": "Request failed"}`，`/v1/models` 静默降级为未登录的 3 个模型。我们的线上因为这多出来的一个字节中断了 14 小时。

## 改动

1. **原子写入**：先写同目录临时文件 + `fsync`，再 `rename` 覆盖目标。同一文件系统内 `rename` 是原子的，读取方永远看到完整文件；中途崩溃只会留下临时文件。
2. **串行化**：模块级队列排队所有对 `data.json` 的 read-modify-write。队列必须是模块级的——进程里存在多个 `DataPersistence` 实例，实例级的锁挡不住。
3. **备份 `data.json.bak`**：解析成功即快照，限流 5 分钟；账户列表为空时不备份，避免 `data.json` 被误删后好备份被空文件冲掉。
4. **损坏时的行为**：有备份 → 把损坏文件留证为 `data.json.corrupt-<时间戳>` 并自动恢复；没有备份 → 大声 ERROR 并原样保留损坏文件，绝不静默地以 0 个账户启动。
5. 账户不可用的原因（文件损坏 / 尚未初始化 / 没有账户）透传给客户端，替代笼统的 `Request failed`。

Redis 模式不受影响。`PM2_INSTANCES > 1` 时队列只在进程内生效，跨进程仍可能「后写覆盖先写」丢一次统计，但原子 rename 保证文件任何时刻都是完整 JSON。

## 验证

- 并发脚本：30 个账户 × 3 轮共 93 次并发保存（两个 `DataPersistence` 实例混用）。改前：文件在 position 4333 处损坏，2 次保存失败；改后：93/93 成功，文件可解析，30 个账户的 stats 齐全。
- 真实环境（11 个账户、Docker、`DATA_SAVE_MODE=file`）：12 个并发 `/v1/chat/completions` → 11 个账户的 stats 全部落盘，无错误日志，重启后账户正常加载。
- 人为在 `data.json` 末尾追加一个 `}`：有备份 → 自动恢复并加载 11 个账户；无备份 → ERROR 日志 + 保留原文件 + 客户端收到「数据文件损坏且无可用备份」。

<details>
<summary>🇷🇺 Русский перевод</summary>

## Проблема

`DataPersistence._saveToFile` работает так: прочитать файл целиком → `JSON.parse` → изменить одну запись → перезаписать через `fs.writeFile`. Ни временного файла, ни очереди.

`saveAccountStats` вешает на каждую учётку свой таймер с задержкой 5 секунд, и таймеры разных учёток легко срабатывают в один момент; вдобавок `routes/settings.js` держит второй объект `DataPersistence`. Когда две последовательности «прочитать-изменить-записать» пересекаются:

- `fs.writeFile` открывает файл с флагом `'w'` и сначала обрезает его до нуля;
- более короткая запись не перекрывает хвост предыдущей, и в конце файла остаётся лишняя `}`.

Дальше каждое сохранение падает на `JSON.parse` (в журнале сотни таких записей), но процесс жив, учётки в памяти, сервис выглядит работающим. До первого перезапуска: `loadAccounts` бросает исключение → `accountTokens = []` → `isInitialized = false` → на любой запрос `{"error": "Request failed"}`, а `/v1/models` молча подменяется набором из 3 моделей без авторизации. Наш боевой сервис пролежал из-за одного лишнего байта 14 часов.

## Изменения

1. **Неделимая запись**: сначала временный файл в том же каталоге + `fsync`, затем `rename` поверх цели. В пределах одной файловой системы `rename` неделим — читающий всегда видит целый файл; обрыв посреди записи оставит только временный файл.
2. **Последовательность**: очередь на уровне модуля выстраивает все операции «прочитать-изменить-записать» над `data.json`. Именно на уровне модуля — в процессе несколько объектов `DataPersistence`, блокировка внутри объекта не спасает.
3. **Резервная копия `data.json.bak`**: слепок делается после каждого успешного разбора, но не чаще раза в 5 минут; пустой список учёток в копию не пишется, иначе случайная потеря `data.json` затёрла бы хорошую копию.
4. **Поведение при повреждении**: копия есть → повреждённый файл сохраняется как `data.json.corrupt-<метка времени>`, данные восстанавливаются автоматически; копии нет → громкая ошибка ERROR, повреждённый файл остаётся нетронутым, молчаливый старт с нулём учёток исключён.
5. Причина недоступности учёток (файл повреждён / инициализация не завершена / нет учёток) передаётся клиенту вместо безликого `Request failed`.

Режим Redis не затронут. При `PM2_INSTANCES > 1` очередь действует только внутри процесса: два процесса всё ещё могут потерять одно обновление статистики (перезапись «последний выиграл»), но повредить файл больше не могут.

## Проверка

- Нагрузочный скрипт: 30 учёток × 3 круга, 93 одновременных сохранения через два объекта `DataPersistence`. До правки: файл повреждён на позиции 4333, 2 сохранения упали. После: 93 из 93 успешно, файл разбирается, статистика у всех 30 учёток.
- Боевые условия (11 учёток, Docker, `DATA_SAVE_MODE=file`): 12 одновременных запросов `/v1/chat/completions` → статистика записана у всех 11, ошибок в журнале нет, после перезапуска учётки загружаются штатно.
- Вручную дописан `}` в конец `data.json`: с копией → автоматическое восстановление и загрузка 11 учёток; без копии → ошибка в журнале, файл сохранён как есть, клиент получает «файл данных повреждён, резервной копии нет».

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
