### PR TITLE
fix(chat): 按 response_id 过滤上游多路候选回答，修复回答复读

### DIFF
--- a/src/controllers/anthropic.js
+++ b/src/controllers/anthropic.js
@@ -11,7 +11,7 @@ const {
   createNativeToolCallAccumulator,
   looksLikeUnexecutedToolAction
 } = require('../utils/tool-prompt.js');
-const { consumeSSEStream } = require('../utils/sse.js');
+const { consumeSSEStream, createUpstreamResponseFilter } = require('../utils/sse.js');
 const { logger } = require('../utils/logger');
 const { assertNoUpstreamFailure } = require('../utils/upstream-error.js');
 const {
@@ -541,12 +541,15 @@ const handleAnthropicStream = async (res, ctx, upstream) => {
   let webSearchInfo = null;
   let thinkingStarted = false;
   const normalizeDelta = createUpstreamDeltaNormalizer();
+  const acceptUpstreamFrame = createUpstreamResponseFilter();
 
   /**
    * 处理一个上游 delta JSON
    * @param {Object} json - 上游 SSE delta
    */
   const onUpstreamDelta = async (json) => {
+    // 丢弃其余候选回答的帧：上游多路并发会让内容重复
+    if (!acceptUpstreamFrame(json)) return;
     if (json.usage) {
       promptTokens = json.usage.prompt_tokens || promptTokens;
       completionTokens = json.usage.completion_tokens || completionTokens;
@@ -738,12 +741,15 @@ const handleAnthropicNonStream = async (res, ctx, upstream) => {
     ? createNativeToolCallAccumulator({ allowedToolNames })
     : null;
   const normalizeDelta = createUpstreamDeltaNormalizer();
+  const acceptUpstreamFrame = createUpstreamResponseFilter();
 
   /**
    * 处理一个上游 delta JSON
    * @param {Object} json - 上游 SSE delta
    */
   const onUpstreamDelta = async (json) => {
+    // 丢弃其余候选回答的帧：上游多路并发会让内容重复
+    if (!acceptUpstreamFrame(json)) return;
     if (json.usage) {
       promptTokens = json.usage.prompt_tokens || promptTokens;
       completionTokens = json.usage.completion_tokens || completionTokens;

--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -7,7 +7,7 @@ const {
     createNativeToolCallAccumulator,
     looksLikeUnexecutedToolAction
 } = require('../utils/tool-prompt.js')
-const { consumeSSEStream } = require('../utils/sse.js')
+const { consumeSSEStream, createUpstreamResponseFilter } = require('../utils/sse.js')
 const accountManager = require('../utils/account.js')
 const config = require('../config/index.js')
 const { logger } = require('../utils/logger')
@@ -172,6 +172,7 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
         let thinking_start = false
         let thinking_end = false
         const normalizeDelta = createUpstreamDeltaNormalizer()
+        const acceptUpstreamFrame = createUpstreamResponseFilter()
         let emittedImageMarkdownSet = new Set()
         let pendingImageMarkdownList = []
 
@@ -337,6 +338,8 @@ const handleStreamResponse = async (res, response, enable_thinking, enable_web_s
             const decodeJson = isJson(dataContent) ? JSON.parse(dataContent) : null
             if (decodeJson === null) return
             assertNoUpstreamFailure(decodeJson)
+            // 丢弃其余候选回答的帧：上游多路并发会让内容重复
+            if (!acceptUpstreamFrame(decodeJson)) return
 
             if (decodeJson.usage) {
                 totalTokens = {
@@ -661,6 +664,7 @@ const handleNonStreamResponse = async (res, response, enable_thinking, enable_we
         let thinking_start = false
         let thinking_end = false
         const normalizeDelta = createUpstreamDeltaNormalizer()
+        const acceptUpstreamFrame = createUpstreamResponseFilter()
         let appendedImageMarkdownSet = new Set()
         let pendingImageMarkdownList = []
 
@@ -704,6 +708,8 @@ const handleNonStreamResponse = async (res, response, enable_thinking, enable_we
             const decodeJson = isJson(dataContent) ? JSON.parse(dataContent) : null
             if (decodeJson === null) return
             assertNoUpstreamFailure(decodeJson)
+            // 丢弃其余候选回答的帧：上游多路并发会让内容重复
+            if (!acceptUpstreamFrame(decodeJson)) return
 
             if (decodeJson.usage) {
                 totalTokens = {

--- a/src/utils/sse.js
+++ b/src/utils/sse.js
@@ -162,9 +162,31 @@ const consumeSSEStream = async (stream, onFrame) => {
     return { sawDone, eventCount, completed: true }
 }
 
+/**
+ * 创建上游并发响应过滤器。
+ * 上游偶尔会对同一次请求开启多路候选回答：先连续下发多个 response.created
+ * （chat_id/parent_id 相同，response_index 为 "0"/"1"，各自 response_id 不同），
+ * 随后两路增量帧交错到达。解析时不区分 response_id 就会把两路内容拼到一起，
+ * 回答被复读（"巴黎巴黎"）。这里锁定第一个带 response_id 的帧，丢弃其余各路。
+ * 上游未带 response_id 时（旧协议）一律放行。
+ * @returns {(json: object) => boolean} true 表示该帧属于已锁定的那一路，应继续处理
+ */
+const createUpstreamResponseFilter = () => {
+    let acceptedId = null
+    return (json) => {
+        const responseId = json && json.response_id
+        if (!responseId) return true
+        if (acceptedId === null) {
+            acceptedId = responseId
+        }
+        return responseId === acceptedId
+    }
+}
+
 module.exports = {
     SSEDecoder,
     parseSSEFrame,
     formatSSEFrame,
-    consumeSSEStream
+    consumeSSEStream,
+    createUpstreamResponseFilter
 }

--- a/tests/agent-protocol.test.js
+++ b/tests/agent-protocol.test.js
@@ -457,3 +457,37 @@ test('non-stream responses preserve truncation for both protocols', async () => 
   )
   assert.match(anthropicRes.output, /"stop_reason":"max_tokens"/)
 })
+
+test('interleaved multi-response frames are not merged into a duplicated answer', async () => {
+  // 上游偶尔对同一次请求开启多路候选回答：先下发两个 response.created
+  // （response_index "0"/"1"，各自 response_id 不同），随后两路增量帧交错到达。
+  // 不按 response_id 区分就会把两路内容拼在一起，回答被复读（问题 #149）。
+  // 下列帧取自 chat.qwen.ai 实际抓包。
+  const dualResponseFrames = [
+    'data: {"response.created":{"chat_id":"d8e2ce75","parent_id":"4cc3a56d","response_id":"4f79335b","response_index":"0"}}\n\n',
+    'data: {"response.created":{"chat_id":"d8e2ce75","parent_id":"4cc3a56d","response_id":"4c2b7c86","response_index":"1"}}\n\n',
+    'data: {"choices":[{"delta":{"role":"assistant","content":"巴","phase":"answer","status":"typing"}}],"response_id":"4c2b7c86"}\n\n',
+    'data: {"choices":[{"delta":{"role":"assistant","content":"巴","phase":"answer","status":"typing"}}],"response_id":"4f79335b"}\n\n',
+    'data: {"choices":[{"delta":{"role":"assistant","content":"黎","phase":"answer","status":"typing"}}],"response_id":"4c2b7c86"}\n\n',
+    'data: {"choices":[{"delta":{"content":"","role":"assistant","status":"finished","phase":"answer"}}],"response_id":"4c2b7c86"}\n\n',
+    'data: {"choices":[{"delta":{"role":"assistant","content":"黎","phase":"answer","status":"typing"}}],"response_id":"4f79335b"}\n\n',
+    'data: {"choices":[{"delta":{"content":"","role":"assistant","status":"finished","phase":"answer"}}],"response_id":"4f79335b"}\n\n',
+    'data: [DONE]\n\n'
+  ]
+
+  const readAnswer = (output) => output
+    .split('\n\n')
+    .map(frame => frame.replace(/^data: /, '').trim())
+    .filter(frame => frame && frame !== '[DONE]')
+    .map(frame => JSON.parse(frame))
+    .map(json => json.choices?.[0]?.delta?.content || '')
+    .join('')
+
+  const streamRes = createMockResponse()
+  await handleStreamResponse(streamRes, Readable.from(dualResponseFrames), false, false, { messages: [] }, {})
+  assert.equal(readAnswer(streamRes.output), '巴黎')
+
+  const nonStreamRes = createMockResponse()
+  await handleNonStreamResponse(nonStreamRes, Readable.from(dualResponseFrames), false, false, { messages: [] }, {})
+  assert.equal(JSON.parse(nonStreamRes.output).choices[0].message.content, '巴黎')
+})

--- a/tests/sse.test.js
+++ b/tests/sse.test.js
@@ -5,7 +5,8 @@ const { PassThrough, Readable } = require('node:stream')
 const {
   SSEDecoder,
   consumeSSEStream,
-  formatSSEFrame
+  formatSSEFrame,
+  createUpstreamResponseFilter
 } = require('../src/utils/sse.js')
 
 test('SSEDecoder handles arbitrary TCP, UTF-8 and CRLF boundaries', () => {
@@ -71,4 +72,42 @@ test('formatSSEFrame produces a frame that survives byte-by-byte decoding', asyn
   assert.equal(frames[0].event, 'message')
   assert.equal(frames[0].id, '42')
   assert.equal(frames[0].data, '第一行\n第二行')
+})
+
+// 上游偶尔对同一次请求开启多路候选回答，两路帧交错到达；
+// 帧样本取自 chat.qwen.ai 实际抓包（问题 #149，回答被复读成 "巴黎巴黎"）。
+const DUAL_RESPONSE_FRAMES = [
+  '{"response.created":{"chat_id":"d8e2ce75","parent_id":"4cc3a56d","response_id":"4f79335b","response_index":"0"}}',
+  '{"response.created":{"chat_id":"d8e2ce75","parent_id":"4cc3a56d","response_id":"4c2b7c86","response_index":"1"}}',
+  '{"choices":[{"delta":{"role":"assistant","content":"巴","phase":"answer","status":"typing"}}],"response_id":"4c2b7c86"}',
+  '{"choices":[{"delta":{"role":"assistant","content":"巴","phase":"answer","status":"typing"}}],"response_id":"4f79335b"}',
+  '{"choices":[{"delta":{"role":"assistant","content":"黎","phase":"answer","status":"typing"}}],"response_id":"4c2b7c86"}',
+  '{"choices":[{"delta":{"content":"","role":"assistant","status":"finished","phase":"answer"}}],"response_id":"4c2b7c86"}',
+  '{"choices":[{"delta":{"role":"assistant","content":"黎","phase":"answer","status":"typing"}}],"response_id":"4f79335b"}',
+  '{"choices":[{"delta":{"content":"","role":"assistant","status":"finished","phase":"answer"}}],"response_id":"4f79335b"}'
+]
+
+const collectAnswer = (rawFrames, accept) => {
+  let answer = ''
+  for (const raw of rawFrames) {
+    const json = JSON.parse(raw)
+    if (accept && !accept(json)) continue
+    if (!json.choices || json.choices.length === 0) continue
+    answer += json.choices[0].delta?.content || ''
+  }
+  return answer
+}
+
+test('createUpstreamResponseFilter keeps a single response when upstream opens several', () => {
+  // 不过滤时两路内容被拼在一起 —— 这正是 #149 的复读现象
+  assert.equal(collectAnswer(DUAL_RESPONSE_FRAMES, null), '巴巴黎黎')
+  assert.equal(collectAnswer(DUAL_RESPONSE_FRAMES, createUpstreamResponseFilter()), '巴黎')
+})
+
+test('createUpstreamResponseFilter passes frames through when upstream sends no response_id', () => {
+  const legacyFrames = [
+    '{"choices":[{"delta":{"role":"assistant","content":"巴","phase":"answer"}}]}',
+    '{"choices":[{"delta":{"role":"assistant","content":"黎","phase":"answer"}}]}'
+  ]
+  assert.equal(collectAnswer(legacyFrames, createUpstreamResponseFilter()), '巴黎')
 })


### PR DESCRIPTION
## 问题

上游偶尔会对同一次请求开启多路候选回答：先连续下发多个 `response.created`（chat_id/parent_id 相同，`response_index` 为 `"0"`/`"1"`，各自 `response_id` 不同），随后两路增量帧交错到达，每帧都带自己的 `response_id`。

解析时不区分 `response_id` 就会把两路内容拼到一起，回答被复读。两路帧的到达顺序不固定，所以复读既可能是「巴黎巴黎」，也可能是交错的「巴巴黎黎」。

抓到的原始帧（问题 #149）：

```
data: {"response.created":{"chat_id":"d8e2ce75","parent_id":"4cc3a56d","response_id":"4f79335b","response_index":"0"}}
data: {"response.created":{"chat_id":"d8e2ce75","parent_id":"4cc3a56d","response_id":"4c2b7c86","response_index":"1"}}
data: {"choices":[{"delta":{"content":"巴",...}}],"response_id":"4c2b7c86"}
data: {"choices":[{"delta":{"content":"巴",...}}],"response_id":"4f79335b"}
data: {"choices":[{"delta":{"content":"黎",...}}],"response_id":"4c2b7c86"}
data: {"choices":[{"delta":{"content":"黎",...}}],"response_id":"4f79335b"}
```

两路帧的 `content` 与 `usage` 完全一致，只有 `response_id` 不同。

关联 #149

## 改动

- `sse.js` 新增 `createUpstreamResponseFilter()`：锁定第一个带 `response_id` 的帧，丢弃其余各路；上游不带 `response_id` 时（旧协议）一律放行
- 接入 `chat.js` 的流式 / 非流式两处，以及 `anthropic.js` 的两处 `onUpstreamDelta`
- 未锁定 `response_index === "0"`：万一主响应那一路始终不下发内容就会返回空回答，比复读更糟

## 测试

新增 3 个用例，帧样本取自 chat.qwen.ai 实际抓包：

- `tests/sse.test.js` 两个单元用例（多路过滤 + 旧协议放行）
- `tests/agent-protocol.test.js` 一个集成用例，跑通 `handleStreamResponse` 与 `handleNonStreamResponse`

`npm test` 36 项全通过（改动前 33 项）。去掉本次改动后，集成用例复现「巴巴黎黎」。

实测（qwen3.7-max，`enable_thinking=false`，两端交叉对照 12 组）：未修复端复读 6 次，修复端 0 次；抓包确认其中 2 次上游确实开了两路响应。

<details><summary>По-русски</summary>

**Проблема.** Qwen иногда открывает несколько ответов-кандидатов на один запрос: в начале потока идут два кадра `response.created` с одинаковыми `chat_id` и `parent_id`, но разными `response_id` и `response_index` «0» и «1». Дальше кадры обоих ответов приходят вперемежку, каждый со своим `response_id`. Содержимое и счётчики токенов у них совпадают — различается только `response_id`. Разбор его игнорирует и склеивает оба потока в один текст, ответ удваивается. Порядок прихода не фиксирован, отсюда две формы искажения: «ПарижПариж» и «ППарижариж».

**Правка.** Фильтровать кадры по `response_id`, закрепляя первый пришедший, и отбрасывать остальные. Кадры без `response_id` (старый протокол) проходят как есть. Врезано в четыре места разбора. Привязку к `response_index: "0"` отверг: если основной поток не наполнится содержимым, клиент получит пустой ответ — это хуже удвоения.

**Проверка.** Три теста на настоящей записи двойного ответа, весь набор — 36 тестов. Без правки интеграционный тест воспроизводит удвоение. Плюс замер на живом сервисе: 12 пар запросов вперемежку, без правки 6 искажений, с правкой 0.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
