### PR TITLE
refactor(status): 账户健康与 CLI 可用性拆成两个字段

### DIFF
--- a/public/src/views/dashboard.vue
+++ b/public/src/views/dashboard.vue
@@ -227,23 +227,23 @@
                 <template v-if="isCliInactive(token.email)">
                   <div class="flex items-baseline justify-between gap-2 w-full text-left">
                     <span class="text-gray-400 border-b border-dotted border-gray-300 transition-colors"
-                          :title="getStatusTooltip(token.email)">
+                          :title="getCliTooltip(token.email)">
                       {{ t('dash.acct.cliToday') }}:
                     </span>
                     <span class="font-medium text-gray-400 text-xs md:text-sm"
-                          :title="getStatusTooltip(token.email)">
+                          :title="getCliTooltip(token.email)">
                       {{ getCliInactiveLabel(token.email) }}
                     </span>
                   </div>
                 </template>
-                <template v-else-if="getStatusKind(token.email) === 'cli_pending'">
+                <template v-else-if="getCliState(token.email) === 'pending'">
                   <div class="flex items-baseline justify-between gap-2 w-full text-left">
                     <span class="text-blue-400 border-b border-dotted border-blue-300 transition-colors"
-                          :title="getStatusTooltip(token.email)">
+                          :title="getCliTooltip(token.email)">
                       {{ t('dash.acct.cliToday') }}:
                     </span>
                     <span class="font-medium text-blue-400 text-xs md:text-sm"
-                          :title="getStatusTooltip(token.email)">
+                          :title="getCliTooltip(token.email)">
                       {{ t('dash.acct.cliPendingShort') }}
                     </span>
                   </div>
@@ -260,7 +260,7 @@
                   </span>
                 </button>
                 <transition name="fade">
-                  <div v-if="cliExpanded && !isCliInactive(token.email) && getStatusKind(token.email) !== 'cli_pending'" class="space-y-1 pt-1">
+                  <div v-if="cliExpanded && getCliState(token.email) === 'available'" class="space-y-1 pt-1">
                     <div class="text-xs text-gray-500 text-right">
                       {{ t('dash.acct.cliSuccess') }}: {{ getAccountStats(token.email).cli.calls }}
                     </div>
@@ -649,21 +649,20 @@ const toggleCliExpanded = () => {
   localStorage.setItem('cliExpanded', cliExpanded.value ? '1' : '0')
 }
 
-// Per-account status indicator (Qwen2API-3wg.3)
+// Per-account health indicator (Qwen2API-3wg.3, split in Qwen2API-jev).
+// Only account health lives here — CLI availability is a separate axis (status.cli)
+// shown in the CLI row, so a disabled CLI can no longer hide a cooldown.
 const STATUS_EMOJI = Object.freeze({
   active: '🟢',
   warn: '🟡',
   cooldown: '🔴',
-  token_expiring: '🪫',
-  cli_unsupported: '⚪',
-  cli_disabled: '⚫',
-  cli_pending: '🔵'
+  token_expiring: '🪫'
 })
 
 // CLI counters make no sense for these states — show a short label instead of 0 / quota.
 const CLI_INACTIVE_LABELS = Object.freeze({
-  cli_unsupported: 'dash.acct.cliUnavailableShort',
-  cli_disabled: 'dash.acct.cliDisabledShort'
+  unsupported: 'dash.acct.cliUnavailableShort',
+  disabled: 'dash.acct.cliDisabledShort'
 })
 const nowTick = ref(Date.now())
 let tickInterval = null
@@ -673,8 +672,9 @@ const cooldownRefetched = new Map()
 
 const getStatusKind = (email) => accountStats.value[email]?.status?.kind || 'active'
 const getStatusEmoji = (email) => STATUS_EMOJI[getStatusKind(email)] || STATUS_EMOJI.active
-const isCliInactive = (email) => Boolean(CLI_INACTIVE_LABELS[getStatusKind(email)])
-const getCliInactiveLabel = (email) => t(CLI_INACTIVE_LABELS[getStatusKind(email)])
+const getCliState = (email) => accountStats.value[email]?.status?.cli || 'available'
+const isCliInactive = (email) => Boolean(CLI_INACTIVE_LABELS[getCliState(email)])
+const getCliInactiveLabel = (email) => t(CLI_INACTIVE_LABELS[getCliState(email)])
 const isOnCooldown = (email) => {
   const s = accountStats.value[email]?.status
   return s?.kind === 'cooldown' && typeof s?.cooldownEndsAt === 'number'
@@ -715,16 +715,22 @@ const getStatusTooltip = (email) => {
   if (kind === 'token_expiring') {
     return t('dash.acct.status.tokenExpiring')
   }
-  if (kind === 'cli_unsupported') {
+  return t('dash.acct.status.active')
+}
+
+// CLI row hint — independent of the health badge above.
+const getCliTooltip = (email) => {
+  const cli = getCliState(email)
+  if (cli === 'unsupported') {
     return t('dash.acct.status.cliUnsupported')
   }
-  if (kind === 'cli_disabled') {
+  if (cli === 'disabled') {
     return t('dash.acct.status.cliDisabled')
   }
-  if (kind === 'cli_pending') {
+  if (cli === 'pending') {
     return t('dash.acct.status.cliPending')
   }
-  return t('dash.acct.status.active')
+  return ''
 }
 
 const fetchAccountStats = async () => {

--- a/src/routes/accounts.js
+++ b/src/routes/accounts.js
@@ -623,14 +623,15 @@ router.post('/forceRefreshAllAccounts', adminKeyVerify, async (req, res) => {
 /**
  * GET /accountStats
  * 返回 dashboard 用 daily stats + per-account status
- * Status priority: cooldown > warn > token_expiring > active
+ * status.kind —— 账户健康，优先级 cooldown > warn > token_expiring > active
+ * status.cli  —— CLI 可用性，与健康互不遮挡：disabled / unsupported / pending / available
  *
  * @returns {{
  *   accounts: Array<{
  *     email: string,
  *     stats: { chat: {input,output}, cli: {calls,input,output} },
  *     cliRequestNumber: number,
- *     status: { kind: string, cooldownEndsAt: number|null, lastErrorAt: number|null, lastErrorCode: string|number|null }
+ *     status: { kind: string, cli: string, cooldownEndsAt: number|null, lastErrorAt: number|null, lastErrorCode: string|number|null }
  *   }>,
  *   cliQuotaLimit: number
  * }}

--- a/src/utils/cli-support.js
+++ b/src/utils/cli-support.js
@@ -1,5 +1,30 @@
 const DEFAULT_CLI_QUOTA_LIMIT = 2000
 
+/**
+ * CLI 对该账户是否可用——与账户健康无关的独立维度
+ * @param {Object} account - 账户对象
+ * @returns {'disabled'|'unsupported'|'pending'|'available'}
+ */
+function getCliAvailability(account) {
+  const reason = account.cli_unavailable_reason || null
+  if (reason === 'unsupported') return 'unsupported'
+  if (reason === 'disabled') return 'disabled'
+  if (!account.cli_info) return 'pending'
+  return 'available'
+}
+
+/**
+ * 账户状态拆成两个互不遮挡的维度：
+ * - status.kind —— 账户健康（面板角标）：cooldown > warn > token_expiring > active
+ * - status.cli  —— CLI 可用性（卡片里的 CLI 行）：disabled / unsupported / pending / available
+ *
+ * 合成一个字段会互相遮挡：ENABLE_CLI=false 时每个账户都是 cli_disabled，
+ * 冷却中或令牌将过期的账户与正常账户看起来完全一样。
+ *
+ * @param {Object} account - 账户对象
+ * @param {Object} rotatorRecord - 轮询器里该账户的记录
+ * @param {number} now - 当前时间戳
+ */
 function getAccountCliState(account, rotatorRecord = {}, now = Date.now()) {
   const WARN_WINDOW_MS = 15 * 60 * 1000
   const TOKEN_EXPIRING_MS = 6 * 60 * 60 * 1000
@@ -8,15 +33,10 @@ function getAccountCliState(account, rotatorRecord = {}, now = Date.now()) {
   const lastErrorAt = rotatorRecord.lastErrorAt || null
   const lastErrorCode = rotatorRecord.lastErrorCode || null
   const cliUnavailableReason = account.cli_unavailable_reason || null
+  const cli = getCliAvailability(account)
 
   let kind = 'active'
-  if (cliUnavailableReason === 'unsupported') {
-    kind = 'cli_unsupported'
-  } else if (cliUnavailableReason === 'disabled') {
-    kind = 'cli_disabled'
-  } else if (!account.cli_info && !cliUnavailableReason) {
-    kind = 'cli_pending'
-  } else if (cooldownEndsAt && now < cooldownEndsAt) {
+  if (cooldownEndsAt && now < cooldownEndsAt) {
     kind = 'cooldown'
   } else if (lastErrorAt && (now - lastErrorAt) < WARN_WINDOW_MS) {
     kind = 'warn'
@@ -27,9 +47,10 @@ function getAccountCliState(account, rotatorRecord = {}, now = Date.now()) {
   return {
     stats: account.stats || { chat: { input: 0, output: 0 }, cli: { calls: 0, input: 0, output: 0 } },
     cliRequestNumber: account.cli_info?.request_number || 0,
-    cliQuotaLimit: kind === 'cli_unsupported' ? 0 : DEFAULT_CLI_QUOTA_LIMIT,
+    cliQuotaLimit: cli === 'available' ? DEFAULT_CLI_QUOTA_LIMIT : 0,
     status: {
       kind,
+      cli,
       cooldownEndsAt,
       lastErrorAt,
       lastErrorCode,
@@ -40,5 +61,6 @@ function getAccountCliState(account, rotatorRecord = {}, now = Date.now()) {
 
 module.exports = {
   DEFAULT_CLI_QUOTA_LIMIT,
+  getCliAvailability,
   getAccountCliState
 }

--- a/tests/account-cli-disabled.test.js
+++ b/tests/account-cli-disabled.test.js
@@ -35,7 +35,7 @@ test('loadAccountTokens marks every account as cli_disabled when CLI is off', as
     for (const account of accountManager.accountTokens) {
       assert.equal(account.cli_unavailable_reason, 'disabled')
       assert.equal(account.cli_info, null)
-      assert.equal(getAccountCliState(account).status.kind, 'cli_disabled')
+      assert.equal(getAccountCliState(account).status.cli, 'disabled')
     }
   } finally {
     config.cliEnabled = originalCliEnabled

--- a/tests/cli-support.test.js
+++ b/tests/cli-support.test.js
@@ -39,7 +39,7 @@ test('pollForToken stops after 3 unsuccessful attempts', async () => {
   }
 });
 
-test('getAccountCliState marks unsupported CLI accounts with zero quota', () => {
+test('getAccountCliState reports unsupported CLI without touching account health', () => {
   const state = cliSupport.getAccountCliState({
     cli_info: null,
     cli_unavailable_reason: 'unsupported',
@@ -47,7 +47,8 @@ test('getAccountCliState marks unsupported CLI accounts with zero quota', () => 
     stats: { chat: { input: 0, output: 0 }, cli: { calls: 0, input: 0, output: 0 } }
   }, {}, Date.now());
 
-  assert.equal(state.status.kind, 'cli_unsupported');
+  assert.equal(state.status.cli, 'unsupported');
+  assert.equal(state.status.kind, 'active');
   assert.equal(state.cliQuotaLimit, 0);
   assert.equal(state.cliRequestNumber, 0);
 });
@@ -60,11 +61,12 @@ test('getAccountCliState keeps normal accounts on default CLI quota', () => {
   }, {}, Date.now());
 
   assert.equal(state.status.kind, 'active');
+  assert.equal(state.status.cli, 'available');
   assert.equal(state.cliQuotaLimit, 2000);
   assert.equal(state.cliRequestNumber, 12);
 });
 
-test('getAccountCliState marks uninitialized accounts as cli_pending', () => {
+test('getAccountCliState marks uninitialized accounts as CLI pending', () => {
   const state = cliSupport.getAccountCliState({
     cli_info: null,
     cli_unavailable_reason: null,
@@ -72,7 +74,42 @@ test('getAccountCliState marks uninitialized accounts as cli_pending', () => {
     stats: { chat: { input: 0, output: 0 }, cli: { calls: 0, input: 0, output: 0 } }
   }, {}, Date.now());
 
-  assert.equal(state.status.kind, 'cli_pending');
-  assert.equal(state.cliQuotaLimit, 2000);
+  assert.equal(state.status.cli, 'pending');
+  assert.equal(state.status.kind, 'active');
+  assert.equal(state.cliQuotaLimit, 0);
   assert.equal(state.cliRequestNumber, 0);
+});
+
+// The whole point of splitting kind and cli: with a single field the disabled CLI
+// shadowed every health state, so a cooling-down account looked perfectly normal.
+test('CLI availability never shadows account health', () => {
+  const now = Date.now();
+
+  const cooling = cliSupport.getAccountCliState({
+    cli_info: null,
+    cli_unavailable_reason: 'disabled',
+    expires: Math.floor(now / 1000) + 24 * 60 * 60,
+    stats: { chat: { input: 0, output: 0 }, cli: { calls: 0, input: 0, output: 0 } }
+  }, { cooldownEndsAt: now + 60 * 1000 }, now);
+
+  assert.equal(cooling.status.kind, 'cooldown');
+  assert.equal(cooling.status.cli, 'disabled');
+  assert.equal(cooling.status.cooldownEndsAt, now + 60 * 1000);
+
+  const expiring = cliSupport.getAccountCliState({
+    cli_info: null,
+    cli_unavailable_reason: 'disabled',
+    expires: Math.floor(now / 1000) + 60 * 60,
+    stats: { chat: { input: 0, output: 0 }, cli: { calls: 0, input: 0, output: 0 } }
+  }, {}, now);
+
+  assert.equal(expiring.status.kind, 'token_expiring');
+  assert.equal(expiring.status.cli, 'disabled');
+});
+
+test('getCliAvailability maps every unavailability reason', () => {
+  assert.equal(cliSupport.getCliAvailability({ cli_unavailable_reason: 'disabled' }), 'disabled');
+  assert.equal(cliSupport.getCliAvailability({ cli_unavailable_reason: 'unsupported' }), 'unsupported');
+  assert.equal(cliSupport.getCliAvailability({ cli_info: null }), 'pending');
+  assert.equal(cliSupport.getCliAvailability({ cli_info: { request_number: 1 } }), 'available');
 });

--- a/tests/dashboard-cli-unsupported.test.js
+++ b/tests/dashboard-cli-unsupported.test.js
@@ -6,23 +6,32 @@ const dashboard = fs.readFileSync(require.resolve('../public/src/views/dashboard
 
 test('dashboard renders inactive CLI states as hover-only gray hint', () => {
   assert.match(dashboard, /v-if="isCliInactive\(token\.email\)"/);
-  assert.match(dashboard, /\:title="getStatusTooltip\(token\.email\)"/);
+  assert.match(dashboard, /\:title="getCliTooltip\(token\.email\)"/);
   assert.match(dashboard, /getCliInactiveLabel\(token\.email\)/);
   assert.match(dashboard, /text-gray-400/);
-  assert.match(dashboard, /v-if="cliExpanded && !isCliInactive\(token\.email\) && getStatusKind\(token\.email\) !== 'cli_pending'"/);
+  assert.match(dashboard, /v-if="cliExpanded && getCliState\(token\.email\) === 'available'"/);
 });
 
 test('inactive CLI states cover both unsupported and disabled', () => {
-  assert.match(dashboard, /cli_unsupported: 'dash\.acct\.cliUnavailableShort'/);
-  assert.match(dashboard, /cli_disabled: 'dash\.acct\.cliDisabledShort'/);
-  assert.match(dashboard, /cli_disabled: '⚫'/);
-  assert.match(dashboard, /kind === 'cli_disabled'/);
+  assert.match(dashboard, /unsupported: 'dash\.acct\.cliUnavailableShort'/);
+  assert.match(dashboard, /disabled: 'dash\.acct\.cliDisabledShort'/);
+  assert.match(dashboard, /cli === 'disabled'/);
 });
 
 test('dashboard renders pending CLI state as blue hint', () => {
-  assert.match(dashboard, /v-else-if="getStatusKind\(token\.email\) === 'cli_pending'"/);
+  assert.match(dashboard, /v-else-if="getCliState\(token\.email\) === 'pending'"/);
   assert.match(dashboard, /cliPendingShort/);
   assert.match(dashboard, /text-blue-400/);
+});
+
+// The badge answers "is this account alive"; CLI availability must not leak into it.
+test('status badge carries only health states', () => {
+  const map = dashboard.match(/const STATUS_EMOJI = Object\.freeze\(\{[^}]+\}\)/);
+  assert.ok(map, 'STATUS_EMOJI map not found');
+  assert.doesNotMatch(map[0], /cli_/);
+  for (const kind of ['active', 'warn', 'cooldown', 'token_expiring']) {
+    assert.match(map[0], new RegExp(`${kind}:`));
+  }
 });
 
 test('every locale defines the new cli_disabled strings', () => {


### PR DESCRIPTION
接 #155。那个 PR 让面板正确显示 `cli_disabled`，但暴露出更深的一层：角标本身
把两件不相干的事混成了一个字段。

## 问题

`getAccountCliState()` 用一条链算出 `status.kind`，CLI 状态排在健康状态前面：

```
cli_unsupported > cli_disabled > cli_pending > cooldown > warn > token_expiring > active
```

`ENABLE_CLI` 默认关闭，于是链条永远停在第二项，后面四项根本走不到。结果：
冷却中的账号、令牌 6 小时内过期的账号，与完全正常的账号在面板上一模一样，
全是 ⚫「已关闭」。

角标本该回答「这个账号还活着吗」（令牌有效吗、代理通吗、最近有没有报错），
现在却在回答「CLI 开着吗」。两个维度互相遮挡，信息就这么丢了。

## 改动

`status` 拆成两个互不遮挡的字段：

- `status.kind` —— 只描述账户健康：`cooldown > warn > token_expiring > active`
- `status.cli` —— 只描述 CLI 可用性：`disabled` / `unsupported` / `pending` / `available`

服务端：

- 新增并导出 `getCliAvailability(account)`，`cli_*` 三个 kind 从健康链里移除
- `cliQuotaLimit` 只在 CLI 可用时才是 `DEFAULT_CLI_QUOTA_LIMIT` —— 其余状态没有配额可言
- 更新 `/accountStats` 的返回值文档

面板：

- 角标与其悬停提示只看 `status.kind`（🟢 / 🟡 / 🔴 / 🪫），
  CLI 图标 ⚫ ⚪ 🔵 从 `STATUS_EMOJI` 移除
- CLI 行与其悬停提示只看 `status.cli`，新增 `getCliTooltip()`
- CLI 统计折叠块只在 `available` 时展开

三语文案无需改动 —— 复用 #155 已有的 key。

## 验证

- `node --test tests/*.test.js` —— 61 项全部通过
- 新增用例「CLI 可用性不得遮挡账户健康」：CLI 关闭 + 冷却中 →
  `kind='cooldown'`、`cli='disabled'`；CLI 关闭 + 令牌将过期 → `kind='token_expiring'`
- 新增用例校验 `STATUS_EMOJI` 只剩健康状态
- `cd public && npm run build` 通过

<details>
<summary>Русский перевод</summary>

Продолжение #155. Тот PR научил панель показывать `cli_disabled`, но вскрыл слой
глубже: сам значок смешивает две несвязанные вещи в одном поле.

## Проблема

`getAccountCliState()` считает `status.kind` по одной цепочке, где состояния CLI
стоят перед состояниями здоровья:

```
cli_unsupported > cli_disabled > cli_pending > cooldown > warn > token_expiring > active
```

`ENABLE_CLI` выключен по умолчанию, поэтому цепочка всегда обрывается на втором
пункте и до последних четырёх дело не доходит. В итоге аккаунт в остывании,
аккаунт с истекающим через 6 часов токеном и полностью исправный аккаунт выглядят
одинаково — все чёрные, «Отключено».

Значок должен отвечать на вопрос «жив ли этот аккаунт» (действителен ли токен,
работает ли прокси, были ли недавно ошибки), а отвечает на «включён ли CLI».
Два измерения заслоняют друг друга, и сведения теряются.

## Изменения

`status` разделён на два независимых поля:

- `status.kind` — только здоровье аккаунта: `cooldown > warn > token_expiring > active`
- `status.cli` — только доступность CLI: `disabled` / `unsupported` / `pending` / `available`

Сервер:

- добавлен и экспортирован `getCliAvailability(account)`, три `cli_*` состояния
  убраны из цепочки здоровья
- `cliQuotaLimit` равен `DEFAULT_CLI_QUOTA_LIMIT` только когда CLI доступен —
  в остальных состояниях говорить о квоте нечего
- обновлено описание ответа `/accountStats`

Панель:

- значок и подсказка при наведении берут только `status.kind` (🟢 / 🟡 / 🔴 / 🪫),
  значки CLI ⚫ ⚪ 🔵 убраны из `STATUS_EMOJI`
- строка CLI и её подсказка берут только `status.cli`, добавлен `getCliTooltip()`
- блок статистики CLI разворачивается только при `available`

Тексты на трёх языках не менялись — используются ключи из #155.

## Проверка

- `node --test tests/*.test.js` — 61 из 61 проходят
- новый случай «доступность CLI не должна заслонять здоровье аккаунта»:
  CLI выключен + остывание → `kind='cooldown'`, `cli='disabled'`;
  CLI выключен + истекающий токен → `kind='token_expiring'`
- новый случай проверяет, что в `STATUS_EMOJI` остались только состояния здоровья
- `cd public && npm run build` проходит

</details>
