### PR TITLE
feat(agent): opt-in flags to relax the turn gate for Anthropic clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ LEGACY_REASONING_IN_CONTENT=false # 推理输出格式，false=reasoning_content
 SIMPLE_MODEL_MAP=false        # 简化模型映射 (true/false)
 MODELS_CACHE_TTL=3600         # 模型列表缓存有效期（秒），0=永不过期
 AGENT_TURN_MAX_ATTEMPTS=3     # 单个 Agent 回合生成有效工具调用/最终态的最大尝试数（2-6）
+AGENT_TURN_ALLOW_PROSE_WITH_TOOLS=false  # 允许工具调用回合同时带可见正文（Anthropic 客户端）
+AGENT_TURN_ACCEPT_BARE_FINAL=false       # 允许没有 <agent_final> 包装的可见正文作为正常结束
 AGENT_CONTEXT_FILE_THRESHOLD_BYTES=92160 # 超过阈值时外置完整 Agent 上下文
 AGENT_CONTEXT_LIVE_PROMPT_BYTES=49152     # 外置后仍内联保留的关键任务状态大小
 
@@ -134,6 +136,8 @@ CACHE_MODE=default            # 图片缓存模式 (default/file)
 | `LEGACY_REASONING_IN_CONTENT` | 推理输出格式。默认 `false`=推理走独立的 `reasoning_content` 字段；`true`=旧版行为（`<think>` 并入 `content`） | `true` 或 `false` |
 | `SIMPLE_MODEL_MAP` | 简化模型映射，只返回基础模型不包含变体 | `true` 或 `false` |
 | `MODELS_CACHE_TTL` | 模型列表缓存有效期（秒），过期后下次请求自动向上游刷新；`0` 表示永不过期 | `3600` |
+| `AGENT_TURN_ALLOW_PROSE_WITH_TOOLS` | 放宽回合门禁：允许同一回合既有有效工具调用又有可见正文。Anthropic Messages API 允许 `text` 与 `tool_use` 共存，Claude Code 等客户端因此会被严格模式反复判为 `invalid_tool_call` | `false` |
+| `AGENT_TURN_ACCEPT_BARE_FINAL` | 放宽回合门禁：把有可见正文但缺少 `<agent_final>` 包装的回合按 `finish_reason=stop` 接受，而不是判为 `bare` 并重试 | `false` |
 | `AGENT_TURN_MAX_ATTEMPTS` | 工具请求在一次 HTTP 回合内生成有效 `tool_calls`、明确完成态或阻塞态的最大尝试数；范围 2–6，耗尽后非流式请求返回 HTTP 429/503，SSE 请求返回显式错误帧，绝不伪装成正常 `stop` | `3` |
 | `AGENT_CONTEXT_FILE_THRESHOLD_BYTES` | Agent 请求体超过此大小时，将完整工具定义和历史自动外置为 Qwen 文本文档，避免触发约 128 KiB 的 WAF 限制 | `92160`（90 KiB） |
 | `AGENT_CONTEXT_LIVE_PROMPT_BYTES` | 上下文外置后，实时请求中保留的工具协议、system/developer 指令、原始任务、最近工具进度和当前结果的最大大小 | `49152`（48 KiB） |

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -59,6 +59,12 @@ const config = {
         6,
         Math.max(2, parseInt(process.env.AGENT_TURN_MAX_ATTEMPTS, 10) || 3)
     ),
+    // 面向 Anthropic 风格客户端的回合门禁放宽开关，默认关闭，严格模式行为不变。
+    // Anthropic Messages API 允许同一条 assistant 消息同时携带 text 与 tool_use，
+    // 所以一个完全合规的 Anthropic 客户端在严格模式下反而会被判为无效回合。
+    agentTurnAllowProseWithTools: process.env.AGENT_TURN_ALLOW_PROSE_WITH_TOOLS === 'true',
+    // 把没有 <agent_final> 包装但确有可见正文的回合视为正常结束，而不是 bare。
+    agentTurnAcceptBareFinal: process.env.AGENT_TURN_ACCEPT_BARE_FINAL === 'true',
     // chat.qwen.ai 的 WAF 会在 JSON 请求体接近 128 KiB 时返回 captcha。
     // 提前把 Agent 全量历史外置成文本文档，给协议头和当前回合留出安全余量。
     agentContextFileThresholdBytes: Math.max(

--- a/src/utils/openai-agent-runtime.js
+++ b/src/utils/openai-agent-runtime.js
@@ -285,7 +285,8 @@ const evaluateOpenAIAgentAttempt = (attempt, options = {}) => {
     return { accepted: false, finishReason: null, retryReason: 'invalid_tool_call' }
   }
   if (attempt.toolCalls.length > 0) {
-    if (attempt.controlKind !== 'empty' || attempt.visibleText.trim()) {
+    if (!config.agentTurnAllowProseWithTools &&
+        (attempt.controlKind !== 'empty' || attempt.visibleText.trim())) {
       return { accepted: false, finishReason: null, retryReason: 'invalid_tool_call' }
     }
     return { accepted: true, finishReason: 'tool_calls', retryReason: null }
@@ -304,6 +305,9 @@ const evaluateOpenAIAgentAttempt = (attempt, options = {}) => {
   }
   if (attempt.controlKind === 'invalid_control') {
     return { accepted: false, finishReason: null, retryReason: 'invalid_control' }
+  }
+  if (config.agentTurnAcceptBareFinal && attempt.visibleText.trim()) {
+    return { accepted: true, finishReason: 'stop', retryReason: null }
   }
   return { accepted: false, finishReason: null, retryReason: 'bare' }
 }

--- a/tests/agent-protocol.test.js
+++ b/tests/agent-protocol.test.js
@@ -1018,3 +1018,92 @@ test('interleaved multi-response frames are not merged into a duplicated answer'
   await handleNonStreamResponse(nonStreamRes, Readable.from(dualResponseFrames), false, false, { messages: [] }, {})
   assert.equal(JSON.parse(nonStreamRes.output).choices[0].message.content, '巴黎')
 })
+
+// ---------------------------------------------------------------------------
+// 回合门禁放宽开关（默认关闭，严格行为不变）
+// ---------------------------------------------------------------------------
+const agentTurnConfig = require('../src/config/index.js')
+const { evaluateOpenAIAgentAttempt: evaluateAgentTurn } = require('../src/utils/openai-agent-runtime.js')
+
+const buildAttempt = (overrides = {}) => ({
+  upstreamFinishReason: null,
+  toolErrors: [],
+  toolCalls: [],
+  controlKind: 'empty',
+  visibleText: '',
+  ...overrides
+})
+
+const withAgentTurnFlags = (flags, fn) => {
+  const saved = {
+    agentTurnAllowProseWithTools: agentTurnConfig.agentTurnAllowProseWithTools,
+    agentTurnAcceptBareFinal: agentTurnConfig.agentTurnAcceptBareFinal
+  }
+  Object.assign(agentTurnConfig, flags)
+  try {
+    return fn()
+  } finally {
+    Object.assign(agentTurnConfig, saved)
+  }
+}
+
+test('默认严格模式：工具调用附带可见正文仍判为 invalid_tool_call', () => {
+  const attempt = buildAttempt({
+    toolCalls: [{ id: 'call_1', function: { name: 'read', arguments: '{}' } }],
+    controlKind: 'bare',
+    visibleText: '我先看一下这个文件。'
+  })
+  withAgentTurnFlags({ agentTurnAllowProseWithTools: false }, () => {
+    assert.deepEqual(evaluateAgentTurn(attempt), {
+      accepted: false,
+      finishReason: null,
+      retryReason: 'invalid_tool_call'
+    })
+  })
+})
+
+test('AGENT_TURN_ALLOW_PROSE_WITH_TOOLS 打开后接受正文与工具调用共存', () => {
+  const attempt = buildAttempt({
+    toolCalls: [{ id: 'call_1', function: { name: 'read', arguments: '{}' } }],
+    controlKind: 'bare',
+    visibleText: '我先看一下这个文件。'
+  })
+  withAgentTurnFlags({ agentTurnAllowProseWithTools: true }, () => {
+    assert.deepEqual(evaluateAgentTurn(attempt), {
+      accepted: true,
+      finishReason: 'tool_calls',
+      retryReason: null
+    })
+  })
+})
+
+test('打开放宽开关也不会接受非法工具调用', () => {
+  const attempt = buildAttempt({
+    toolErrors: [{ message: 'truncated tool_call' }],
+    visibleText: '正文'
+  })
+  withAgentTurnFlags({ agentTurnAllowProseWithTools: true, agentTurnAcceptBareFinal: true }, () => {
+    assert.equal(evaluateAgentTurn(attempt).accepted, false)
+    assert.equal(evaluateAgentTurn(attempt).retryReason, 'invalid_tool_call')
+  })
+})
+
+test('默认严格模式：缺少 <agent_final> 包装的正文判为 bare', () => {
+  const attempt = buildAttempt({ controlKind: 'bare', visibleText: '已经改完了。' })
+  withAgentTurnFlags({ agentTurnAcceptBareFinal: false }, () => {
+    assert.equal(evaluateAgentTurn(attempt).retryReason, 'bare')
+  })
+})
+
+test('AGENT_TURN_ACCEPT_BARE_FINAL 打开后按 stop 接受，空正文仍判为 bare', () => {
+  withAgentTurnFlags({ agentTurnAcceptBareFinal: true }, () => {
+    assert.deepEqual(
+      evaluateAgentTurn(buildAttempt({ controlKind: 'bare', visibleText: '已经改完了。' })),
+      { accepted: true, finishReason: 'stop', retryReason: null }
+    )
+    assert.equal(
+      evaluateAgentTurn(buildAttempt({ controlKind: 'bare', visibleText: '   ' })).retryReason,
+      'bare'
+    )
+  })
+})


### PR DESCRIPTION
## 问题 / Problem

Agent 回合门禁（`evaluateOpenAIAgentAttempt`）要求工具调用回合不能带任何可见正文，
且最终回答必须使用 `<agent_final>` 包装。但 **Anthropic Messages API 允许同一条
assistant 消息同时携带 `text` 与 `tool_use`**，Claude Code 这类客户端因此天然违反
该协议：它自带的 system prompt（约 82 KB）明确要求模型解释自己在做什么，模型会
服从更大的那份指令。

结果是 `invalid_tool_call` 反复触发，耗尽 `AGENT_TURN_MAX_ATTEMPTS` 后整个请求失败。

The turn gate rejects any tool-call turn carrying visible prose. Anthropic's
Messages API explicitly allows `text` and `tool_use` in one assistant message,
so a correctly-behaving Anthropic client is penalised for being correct.

## 改动 / Change

两个开关，**默认关闭，严格模式行为逐字节不变**：

| 变量 | 作用 | 默认 |
|---|---|---|
| `AGENT_TURN_ALLOW_PROSE_WITH_TOOLS` | 允许工具调用回合同时带可见正文 | `false` |
| `AGENT_TURN_ACCEPT_BARE_FINAL` | 缺少 `<agent_final>` 包装但有可见正文时按 `finish_reason=stop` 接受 | `false` |

非法/截断的工具调用（`toolErrors`）在开关打开时**仍然被拒绝**，空正文**仍然判为
`bare`**。放宽只作用于「模型做对了但不符合本协议文本形式」的情况。

## 实测 / Measurement

通过 `claude-code-proxy` 打到 `qwen3.8-max`，12 个请求，携带 82 KB 的 Claude Code
system prompt 与 15 个工具定义，4 并发：

| | 失败请求 | 日志中的 `门禁拒绝` |
|---|---|---|
| 默认（严格） | 5 / 12 | 6/6 次尝试全部被拒后 500 |
| 两个开关打开 | **0 / 12** | **0 条** |

已先行排除：`AGENT_TURN_MAX_ATTEMPTS` 已是上限 6；在 system prompt 里追加「工具调用
不要带正文」的指令无效（4/12 vs 5/12，属噪声）。

## 测试 / Tests

`tests/agent-protocol.test.js` 新增 5 个用例，覆盖两个开关的开与关、开关打开时非法
工具调用仍被拒、空正文仍为 `bare`。`node --test tests/agent-protocol.test.js` → 38/38 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)