### PR TITLE
fix(csrf): exempt the admin login endpoint from CSRF validation

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -40,10 +40,15 @@ app.get('/api/csrf-token', (req, res) => {
   res.json({ csrfToken: token, csrfSecret: secret })
 })
 
+// 没有凭证可用的公开端点：管理面板登录接口
+const CSRF_EXEMPT_PATHS = new Set(['/verify'])
+
 // CSRF validation middleware for state-changing browser requests
 // API key clients (Authorization / x-api-key header) are exempt
 const csrfProtect = (req, res, next) => {
   if (['GET', 'HEAD', 'OPTIONS'].includes(req.method)) return next()
+  // 登录请求本身没有凭证可带——它就是登录。放行后仍由 /verify 自己校验 apiKey。
+  if (CSRF_EXEMPT_PATHS.has(req.path)) return next()
   if (req.headers['authorization'] || req.headers['x-api-key']) return next()
   const secret = req.headers['x-csrf-secret']
   const token = req.headers['x-csrf-token']


### PR DESCRIPTION
## 问题 / Problem

#159 引入的 CSRF 中间件放行携带 `authorization` 或 `x-api-key` 的请求。但**管理面板的
登录请求两者都没有**——它就是登录本身。`public/src/views/auth.vue:35` 只带
`Content-Type`：

```js
const res = await axios.post('/verify', { apiKey: apiKey.value }, {
  headers: { 'Content-Type': 'application/json' }
})
```

于是 `POST /verify` 一律返回 403。更麻烦的是 `auth.vue` 的 `catch` 把任何失败都渲染成
同一句「密钥错误」，所以**正确的管理员密钥看起来也是错的**，没有任何线索指向 CSRF。

The CSRF middleware exempts requests carrying credentials, but the login request
has none — it IS the login. Every admin login returns 403, and the panel's catch
renders its generic "wrong key" alert, so a correct key looks wrong.

## 复现 / Reproduced

在运行中的容器上，修复前：

```
POST /verify {"apiKey": "<正确的管理员密钥>"}
-> 403 {"error":"Invalid CSRF token"}
```

修复后：

```
正确密钥 -> 200 {"status":200,"message":"success","isAdmin":true}
错误密钥 -> 401 {"status":401,"message":"Unauthorized"}
```

## 改动 / Change

`src/server.js` 增加一个豁免路径集合，目前只含 `/verify`。

豁免不授予任何权限：`/verify` 仍然自己校验请求体里的 `apiKey`，错误密钥照样 401。
所有会改变状态的管理接口不受影响，仍走 CSRF 或凭证豁免。

The exemption grants nothing — `/verify` still validates the `apiKey` in the body.

`tests/account-cli-disabled.test.js` fails on `upstream/main` as well, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)